### PR TITLE
remove compose profiles

### DIFF
--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -3,8 +3,6 @@ include:
 
 services:
   web:
-    profiles:
-      - backend
     build:
       context: .
       dockerfile: Dockerfile
@@ -26,8 +24,6 @@ services:
       - django_media:/var/media
 
   celery:
-    profiles:
-      - backend
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -1,7 +1,5 @@
 services:
   db:
-    profiles:
-      - backend
     image: postgres:12.22
     healthcheck:
       test: ["CMD", "pg_isready"]
@@ -19,8 +17,6 @@ services:
       - pgdata:/var/lib/postgresql
 
   redis:
-    profiles:
-      - backend
     image: redis:7.4.2
     healthcheck:
       test: ["CMD", "redis-cli", "ping", "|", "grep", "PONG"]
@@ -31,8 +27,6 @@ services:
       - "6379"
 
   nginx:
-    profiles:
-      - backend
     build:
       context: ./nginx
     ports:
@@ -46,8 +40,6 @@ services:
       - ./config:/etc/nginx/templates
 
   litellm:
-    profiles:
-      - backend
     build:
       dockerfile: Dockerfile-litellm
     ports:


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Removes the compose profiles. We don't need them here.

### How can this be tested?
`docker compose up` without COMPOSE_PROFILES in your `.env` file.

