### PR TITLE
Move details/instructions on search parameters to the tool docstrings

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -240,7 +240,8 @@ class ResourceRecommendationBot(BaseChatbot):
 
     INSTRUCTIONS = """You are an assistant helping users find courses from a catalog
 of learning resources. Users can ask about specific topics, levels, or recommendations
-based on their interests or goals.
+based on their interests or goals.  Do not answer questions that are not related to
+educational resources at MIT.
 
 Your job:
 1. Understand the user's intent AND BACKGROUND based on their message.
@@ -259,45 +260,6 @@ ANSWER QUESTIONS.
 If no results are returned, say you could not find any relevant
 resources.  Don't say you're going to try again.  Ask the user if they would like to
 modify their preferences or ask a different question.
-
-Here are some guidelines on when to use the possible filters in the search function:
-
-q: The area of interest requested by the user.  NEVER INCLUDE WORDS SUCH AS "advanced"
-or "introductory" IN THIS PARAMETER! If the user asks for introductory, intermediate,
-or advanced courses, do not include that in the search query, but examine the search
-results to determine which most closely match the user's desired education level and/or
-their educational background (if either is provided) and choose those results to return
-to the user.  If the user asks what other courses are taught by a particular instructor,
-search the catalog for courses taught by that instructor using the instructor's name
-as the value for this parameter.
-
-offered_by: If a user asks for resources "offered by" or "from" an institution,
-you should include this parameter based on the following
-dictionary:
-
-    mitx = "MITx"
-    ocw = "MIT OpenCourseWare"
-    bootcamps = "Bootcamps"
-    xpro = "MIT xPRO"
-    mitpe = "MIT Professional Education"
-    see = "MIT Sloan Executive Education"
-
-DON'T USE THE offered_by FILTER OTHERWISE. Combine 2+ offered_by values in 1 query.
-
-certification: true if the user is interested in resources that offer certificates,
-false if the user does not want resources with a certificate offered.  Do not use
-this filter if the user does not indicate a preference.
-
-free: true if the user is interested in free resources, false if the user is only
-interested in paid resources. Do not used this filter if the user does not indicate
-a preference.
-
-resource_type: If the user mentions courses, programs, videos, or podcasts in
-particular, filter the search by this parameter.  DO NOT USE THE resource_type FILTER
-OTHERWISE. You MUST combine multiple resource types in one request like this:
-"resource_type=course&resource_type=program". Do not attempt more than one query per
-user message. If the user asks for podcasts, filter by both "podcast" and
-"podcast_episode".
 
 Respond in this format:
 - If the user's intent is unclear, ask clarifying questions about users preference on
@@ -325,19 +287,6 @@ Expected Output: Maybe ask whether the user wants to learn how to program, or ju
 AI in their discipline - does this person want to study machine learning? More info
 needed. Then perform a relevant search and send back the best results.
 
-Here are some recommended tool parameters to apply for sample user prompts:
-
-User: "I am interested in learning advanced AI techniques for free"
-Search parameters: q="AI techniques", free=true
-
-User: "I am curious about AI applications for business"
-Search parameters: q="AI business"
-
-User: "I want free basic courses about biology from OpenCourseware"
-Search parameters: q="biology", resource_type=["course"], offered_by: ["ocw"]
-
-User: "I want to learn some advanced mathematics from MITx or OpenCourseware"
-Search parameters: q="mathematics", , offered_by: ["ocw", "mitx]
 
 AGAIN: NEVER USE ANY INFORMATION OUTSIDE OF THE MIT SEARCH RESULTS TO
 ANSWER QUESTIONS.

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -26,32 +26,92 @@ class SearchToolSchema(pydantic.BaseModel):
         free: Filter for free resources only
         certification: Filter for resources offering certificates
         offered_by: Filter by institution offering the resource
+
+    Here are some recommended tool parameters to apply for sample user prompts:
+
+    User: "I am interested in learning advanced AI techniques for free"
+    Search parameters: q="AI techniques", free=true
+
+    User: "I am curious about AI applications for business"
+    Search parameters: q="AI business"
+
+    User: "I want free basic courses about biology from OpenCourseware"
+    Search parameters: q="biology", resource_type=["course"], offered_by: ["ocw"]
+
+    User: "I want to learn some advanced mathematics from MITx or OpenCourseware"
+    Search parameters: q="mathematics", , offered_by: ["ocw", "mitx]
+
     """
 
     q: str = Field(
         description=(
-            "Query to find resources. Never use level terms like 'advanced' here"
+            """The area of interest requested by the user.  NEVER INCLUDE WORDS SUCH AS
+            "advanced" or "introductory" IN THIS PARAMETER! If the user asks for
+            introductory, intermediate, or advanced courses, do not include that in the
+            search query, but examine the search results to determine which most closely
+            match the user's desired education level and/or their educational background
+            (if either is provided) and choose those results to return to the user.  If
+            the user asks what other courses are taught by a particular instructor,
+            search the catalog for courses taught by that  instructor using the
+            instructor's name as the value for this parameter.
+            """
         )
     )
     resource_type: Optional[list[enum_zip("resource_type", LearningResourceType)]] = (
         Field(
             default=None,
-            description="Type of resource to search for: course, program, video, etc",
+            description=(
+                """
+                Type of resource to search for: course, program, video, etc.
+                If the user mentions courses, programs, videos, or podcasts in
+                particular, filter the search by this parameter.  DO NOT USE THE
+                resource_typeFILTER OTHERWISE. You MUST combine multiple resource types
+                in one request like this: "resource_type=course&resource_type=program".
+                Do not attempt more than one query peruser message. If the user asks for
+                podcasts, filter by both "podcast" and "podcast_episode".
+                """
+            ),
         )
     )
     free: Optional[bool] = Field(
         default=None,
-        description="Whether the resource is free to access, true|false",
+        description=(
+            """
+            Whether the resource is free to access, true|false.
+            true if the user is interested in free resources, false if the user is only
+            interested in paid resources. Do not used this filter if the user does not
+            indicate a preference.
+            """
+        ),
     )
     certification: Optional[bool] = Field(
         default=None,
         description=(
-            "Whether the resource offers a certificate upon completion, true|false"
+            """
+            Whether the resource offers a certificate upon completion, true|false.
+            true if the user is interested in resources that offer certificates,
+            false if the user does not want resources with a certificate offered.
+            Do not use this filter if the user does not indicate a preference.
+            """
         ),
     )
     offered_by: Optional[list[enum_zip("resource_type", OfferedBy)]] = Field(
         default=None,
-        description="Institution that offers the resource: ocw, mitxonline, etc",
+        description="""
+            If a user asks for resources "offered by" or "from" an institution,
+            you should include this parameter based on the following
+            dictionary:
+
+                mitx = "MITx"
+                ocw = "MIT OpenCourseWare"
+                bootcamps = "Bootcamps"
+                xpro = "MIT xPRO"
+                mitpe = "MIT Professional Education"
+                see = "MIT Sloan Executive Education"
+
+            DON'T USE THE offered_by FILTER OTHERWISE.
+            Combine 2+ offered_by values in 1 query.
+            """,
     )
 
 


### PR DESCRIPTION

### What are the relevant tickets?
N/A

### Description (What does it do?)
Moves the instructions/details on how to pick search parameters for the recommendation agent to the relevant docstrings in the search tool.


### How can this be tested?
You will need `OPENAI_API_KEY` set in your .env file to the same value as mit-learn on RC.
Also set `AI_DEBUG=True`

Go to http://ai.open.odl.local:8003 and send requests like these; check the network response, in the developer tab, the search parameters should be in a comment at the bottom of the response. Make sure it is picking appropriate parameters:

> "I want free courses or programs about ecology"

> "Are there any economics courses from Sloan that offer certificates?"

> "I'm looking for podcasts about climate change".

Also try off-topic questions like these, it should tell you that it is only supposed to answer questions about MIT learning resources:

> "Is beer related to fermentation?"

> "Who is U2?"

