### PR TITLE
Fix chat UI height

### DIFF
--- a/frontend-demo/src/app/page.tsx
+++ b/frontend-demo/src/app/page.tsx
@@ -42,7 +42,7 @@ const REQUEST_OPTS: AiChatProps["requestOpts"] = {
   },
 }
 
-const StyledChat = styled(AiChat)({
+const Container = styled.div({
   height: "calc(80vh - 72px)",
   marginTop: "16px",
 })
@@ -61,12 +61,14 @@ const HomePage: React.FC = () => {
   }
 
   return (
-    <StyledChat
-      initialMessages={INITIAL_MESSAGES}
-      requestOpts={REQUEST_OPTS}
-      conversationStarters={STARTERS}
-      parseContent={parseContent}
-    />
+    <Container>
+      <AiChat
+        initialMessages={INITIAL_MESSAGES}
+        requestOpts={REQUEST_OPTS}
+        conversationStarters={STARTERS}
+        parseContent={parseContent}
+      />
+    </Container>
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes the chat UI height in learn-ai

### Screenshots (if appropriate):
Before fix (main branch):
![Screenshot 2025-02-25 103444](https://github.com/user-attachments/assets/500f1d61-2615-41c9-b156-9df1ac07c906)


After fix (this branch):

![brave_screenshot_ai open odl local](https://github.com/user-attachments/assets/0b1d5e69-cfee-4be7-880e-2479d618dd80)


### How can this be tested?
Go to http://ai.open.odl.local:8003 - it should look like the last screenshot above, not the first.
