### PR TITLE
add git hash to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,7 @@ RUN poetry install
 
 # Generate commit hash file
 ARG GIT_REF
-RUN mkdir -p /src/static
-RUN echo $GIT_REF >> /src/static/hash.txt
+RUN echo $GIT_REF >> /src/staticfiles/hash.txt
 
 # Add project
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ WORKDIR /src
 RUN python3 -m venv $VIRTUAL_ENV
 RUN poetry install
 
+# Generate commit hash file
+ARG GIT_REF
+RUN mkdir -p /src/static
+RUN echo $GIT_REF >> /src/static/hash.txt
+
 # Add project
 USER root
 COPY . /src


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6880

### Description (What does it do?)
This PR takes the build argument `GIT_REF` in the `Dockerfile` and deposits it in the image under `/src/staticfiles/hash.txt`

### How can this be tested?
 - Build a test image with `docker build . -f Dockerfile --build-arg GIT_REF=4bad616448f9c2f6840c96ae77b1efe8fcb644ce -t web-test`
 - Run `docker run --rm -it --entrypoint bash web-test`
 - Run `cat /src/staticfiles/hash.txt` and verify that the commit hash matches what was passed in
