### PR TITLE
fix git hash path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,21 @@ ARG GIT_REF
 RUN mkdir -p /src/static
 RUN echo $GIT_REF >> /src/static/hash.txt
 
+# Run collectstatic
+ENV DATABASE_URL="postgres://postgres:postgres@localhost:5433/postgres"
+ENV MITOL_SECURE_SSL_REDIRECT="False"
+ENV MITOL_DB_DISABLE_SSL="True"
+ENV MITOL_FEATURES_DEFAULT="True"
+ENV CELERY_TASK_ALWAYS_EAGER="True"
+ENV CELERY_BROKER_URL="redis://localhost:6379/4"
+ENV CELERY_RESULT_BACKEND="redis://localhost:6379/4"
+ENV MITOL_APP_BASE_URL="http://localhost:8002/"
+ENV MAILGUN_KEY="fake_mailgun_key"
+ENV MAILGUN_SENDER_DOMAIN="other.fake.site"
+ENV MITOL_COOKIE_DOMAIN="localhost"
+ENV MITOL_COOKIE_NAME="cookie_monster"
+RUN python3 manage.py collectstatic --noinput --clear
+
 RUN apt-get clean && apt-get purge
 
 USER mitodl

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,15 @@ WORKDIR /src
 RUN python3 -m venv $VIRTUAL_ENV
 RUN poetry install
 
-# Generate commit hash file
-ARG GIT_REF
-RUN echo $GIT_REF >> /src/staticfiles/hash.txt
-
 # Add project
 USER root
 COPY . /src
 WORKDIR /src
+
+# Generate commit hash file
+ARG GIT_REF
+RUN mkdir -p /src/static
+RUN echo $GIT_REF >> /src/static/hash.txt
 
 RUN apt-get clean && apt-get purge
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow up for https://github.com/mitodl/learn-ai/pull/85

### Description (What does it do?)
This fixes the path of `hash.txt` to be in the `/src/static` directory, so it can be picked up by `collectstatic`, and makes sure the directory exists before doing so.

### How can this be tested?
 - Build a test image with `docker build . -f Dockerfile --build-arg GIT_REF=4bad616448f9c2f6840c96ae77b1efe8fcb644ce -t web-test`
 - Run `docker run --rm -it --entrypoint bash web-test`
 - Run `cat /src/static/hash.txt` and verify that the commit hash matches what was passed in