### PR TITLE
Make sentry work for asgi endpoints too

### DIFF
--- a/main/asgi.py
+++ b/main/asgi.py
@@ -8,6 +8,7 @@ import django
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 from django.urls import re_path
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from main.middleware.configs import HTTP_MIDDLEWARE
 from main.middleware.util import apply_middleware
@@ -33,3 +34,5 @@ application = ProtocolTypeRouter(
         ),
     }
 )
+
+application = SentryAsgiMiddleware(application)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sentry was not picking up any data from the asgi endpoints for learn-ai.  This should fix that.



### How can this be tested?
- Set `SENTRY_DSN=<TBD_ask_devops>` in your backend.local.env file
- Run `docker compose up ` and go to http://ai.open.odl.local:8003
- Ask some questions.
- Go to dashboard.heroku.com, check the learn-ai-qa project, you should see some data from `/http/recommendation_agent` urls.

### Additional Context
https://docs.sentry.io/platforms/python/integrations/asgi/

