### PR TITLE
adding debug toolbar urls

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from rest_framework.routers import DefaultRouter
 
@@ -56,3 +56,8 @@ urlpatterns = (
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 )
+
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls)), *urlpatterns]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6959

### Description (What does it do?)
Fixes an error due to django debug toolbar urls not being included in local environments (where debug is True)


### How can this be tested?
1. note that locally on current main hitting localhost:8001 results in a 500
2. checkout this branch
3. error should not be thrown

