### PR TITLE
Send posthog event with metadata for tutorbot

### DIFF
--- a/users/middleware.py
+++ b/users/middleware.py
@@ -39,7 +39,7 @@ class ApisixChannelAuthMiddleware:
             headers[header[0].decode()] = header[1]
 
         if decode_header not in headers:
-            log.error("decode_scope_header: Header %s not found", decode_header)
+            log.debug("decode_scope_header: Header %s not found", decode_header)
             return None
 
         decoded_x_header = base64.b64decode(headers[decode_header])


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7035

### Description (What does it do?)
- Refactors the chatbot posthog event code into its own function, and calls it from both the base `get_completion` function and the Tutorbot overrriden implementation.
- Adds some Tutorbot metadata for the posthog event (edx_module_id, block_siblings, problem, problem_set)
- Changes an error logging statement to a debug statement



### How can this be tested?
- Set `POSTHOG_*` env values to the same as RC.
- Ask both the recommendation bot and tutor bot some questions, then log in to posthog and check that they eventually show up (may take a few minutes) with correct values for the question, answer, and metadata.

