### PR TITLE
Change recommendation bot course links to resource drawer links

### DIFF
--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -129,9 +129,10 @@ async def test_recommendation_bot_initialization_defaults(
 async def test_recommendation_bot_tool(settings, mocker, search_results):
     """The ResourceRecommendationBot tool should be created and function correctly."""
     settings.AI_MIT_SEARCH_LIMIT = 5
+    settings.AI_MIT_SEARCH_DETAIL_URL = "https://test.mit.edu/resource="
     retained_attributes = [
         "title",
-        "url",
+        "id",
         "description",
         "offered_by",
         "free",
@@ -145,6 +146,7 @@ async def test_recommendation_bot_tool(settings, mocker, search_results):
         simple_result = {key: resource.get(key) for key in retained_attributes}
         simple_result["instructors"] = resource.get("runs")[-1].get("instructors")
         simple_result["level"] = resource.get("runs")[-1].get("level")
+        simple_result["url"] = f"https://test.mit.edu/resource={resource.get('id')}"
         expected_results["results"].append(simple_result)
 
     mock_post = mocker.patch(

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -131,7 +131,7 @@ def search_courses(q: str, **kwargs) -> str:
         "certification": kwargs.get("certification"),
     }
     params.update({k: v for k, v in valid_params.items() if v is not None})
-    log.info("Searching MIT API with params: %s", params)
+    log.debug("Searching MIT API with params: %s", params)
     try:
         response = requests.get(settings.AI_MIT_SEARCH_URL, params=params, timeout=30)
         response.raise_for_status()
@@ -139,7 +139,7 @@ def search_courses(q: str, **kwargs) -> str:
         # Simplify the response to only include the main properties
         main_properties = [
             "title",
-            "url",
+            "id",
             "description",
             "offered_by",
             "free",
@@ -149,6 +149,9 @@ def search_courses(q: str, **kwargs) -> str:
         simplified_results = []
         for result in raw_results:
             simplified_result = {k: result.get(k) for k in main_properties}
+            simplified_result["url"] = (
+                f"{settings.AI_MIT_SEARCH_DETAIL_URL}{result.pop('id')}"
+            )
             # Instructors and level will be in the runs data if present
             next_date = result.get("next_start_date", None)
             raw_runs = result.get("runs", [])

--- a/main/settings.py
+++ b/main/settings.py
@@ -584,6 +584,10 @@ AI_MIT_SEARCH_URL = get_string(
     name="AI_MIT_SEARCH_URL",
     default="https://api.learn.mit.edu/api/v1/learning_resources_search/",
 )
+AI_MIT_SEARCH_DETAIL_URL = get_string(
+    name="AI_MIT_SEARCH_DETAIL_URL",
+    default="https://learn.mit.edu/?resource=",
+)
 AI_MIT_SYLLABUS_URL = get_string(
     "AI_MIT_SYLLABUS_URL",
     "https://api.learn.mit.edu/api/v0/vector_content_files_search/",
@@ -643,9 +647,9 @@ APISIX_USERDATA_MAP = {
 }
 
 # OpenTelemetry configuration
-OPENTELEMETRY_ENABLED = get_bool("OPENTELEMETRY_ENABLED", False)  # noqa: FBT003
+OPENTELEMETRY_ENABLED = get_bool("OPENTELEMETRY_ENABLED", default=False)
 OPENTELEMETRY_SERVICE_NAME = get_string("OPENTELEMETRY_SERVICE_NAME", "learn-ai")
-OPENTELEMETRY_INSECURE = get_bool("OPENTELEMETRY_INSECURE", True)
+OPENTELEMETRY_INSECURE = get_bool("OPENTELEMETRY_INSECURE", default=True)
 OPENTELEMETRY_ENDPOINT = get_string("OPENTELEMETRY_ENDPOINT", None)
 OPENTELEMETRY_BATCH_SIZE = get_int("OPENTELEMETRY_BATCH_SIZE", 512)
 OPENTELEMETRY_EXPORT_TIMEOUT_MS = get_int("OPENTELEMETRY_EXPORT_TIMEOUT_MS", 5000)


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/7044

### Description (What does it do?)

Changes course links returned by the recommendation bot to resource drawer links in MIT Learn


### How can this be tested?
- Ask the recommendation bot for some courses/videos/podcasts etc
- Click the links on the results, they should go to the correct MIT Learn resource drawer

