### PR TITLE
Clear throttle cache on ConsumerThrottleLimit.save

### DIFF
--- a/main/constants.py
+++ b/main/constants.py
@@ -12,3 +12,5 @@ VALID_HTTP_METHODS = ["get", "post", "patch", "delete"]
 
 
 DURATION_MAPPING = {"minute": 60, "hour": 3600, "day": 86400, "week": 604800}
+
+CONSUMER_THROTTLES_KEY = "consumer_throttles"

--- a/main/consumer_throttles.py
+++ b/main/consumer_throttles.py
@@ -12,13 +12,10 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache as default_cache
 from django.core.exceptions import ImproperlyConfigured
 
-from main.constants import DURATION_MAPPING
+from main.constants import CONSUMER_THROTTLES_KEY, DURATION_MAPPING
 from main.models import ConsumerThrottleLimit
 
 log = logging.getLogger(__name__)
-
-
-CONSUMER_THROTTLES_KEY = "consumer_throttles"
 
 
 class AsyncBaseThrottle(ABC):

--- a/main/models.py
+++ b/main/models.py
@@ -2,9 +2,11 @@
 Classes related to models for main
 """
 
+from django.core.cache import cache
 from django.db.models import CharField, DateTimeField, IntegerField, Model
 from django.db.models.query import QuerySet
 
+from main.constants import CONSUMER_THROTTLES_KEY
 from main.utils import now_in_utc
 
 
@@ -77,3 +79,8 @@ class ConsumerThrottleLimit(Model):
             Auth {self.auth_limit}, \
             Anon {self.anon_limit} \
             per {self.interval}"
+
+    def save(self, **kwargs):
+        """Override save to reset the throttles cache"""
+        cache.delete(CONSUMER_THROTTLES_KEY)
+        return super().save(**kwargs)

--- a/main/models.py
+++ b/main/models.py
@@ -83,4 +83,5 @@ class ConsumerThrottleLimit(Model):
     def save(self, **kwargs):
         """Override save to reset the throttles cache"""
         cache.delete(CONSUMER_THROTTLES_KEY)
+        cache.close()
         return super().save(**kwargs)

--- a/main/models_test.py
+++ b/main/models_test.py
@@ -1,0 +1,39 @@
+"""main models tests"""
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from main.consumer_throttles import UserScopedRateThrottle
+from main.factories import ConsumerThrottleLimitFactory
+
+
+@pytest.mark.django_db
+async def test_throttle_limit_save_reset_cache():
+    """Saving changes to the throttle limit model should reset the cache"""
+    auth_limits = (20, 10)
+    anon_limits = (10, 5)
+    intervals = ("minute", "hour")
+
+    throttle_limit = await sync_to_async(ConsumerThrottleLimitFactory.create)(
+        auth_limit=auth_limits[0],
+        anon_limit=anon_limits[0],
+        interval=intervals[0],
+    )
+    scoped_throttle = UserScopedRateThrottle()
+    scoped_throttle.scope = throttle_limit.throttle_key
+    assert await scoped_throttle.get_rate() == {
+        "throttle_key": throttle_limit.throttle_key,
+        "auth_limit": auth_limits[0],
+        "anon_limit": anon_limits[0],
+        "interval": intervals[0],
+    }
+    throttle_limit.auth_limit = auth_limits[1]
+    throttle_limit.anon_limit = anon_limits[1]
+    throttle_limit.interval = intervals[1]
+    await throttle_limit.asave()
+    assert await scoped_throttle.get_rate() == {
+        "throttle_key": throttle_limit.throttle_key,
+        "auth_limit": auth_limits[1],
+        "anon_limit": anon_limits[1],
+        "interval": intervals[1],
+    }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7107

### Description (What does it do?)
Overrides the `ConsumerThrottleLimit.save` function to clear the throttle cache.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Change the existing `ConsumerThrottleLimit` with key `recommendation_bot` to 1/hour for auth and anon users at http://ai.open.odl.local:8002/admin/main/consumerthrottlelimit/
- Try to make more 2+ requests in short order from the home page.  After the 1st you should get a message like "Please try again in 59m"
- Go back to http://ai.open.odl.local:8002/admin/main/consumerthrottlelimit/ and change the interval to "minute"
- Try to make more requests, you should get a message like "Please try again in 52s"

