### PR TITLE
include credentials in edx requests

### DIFF
--- a/frontend-demo/src/services/openedx/client.ts
+++ b/frontend-demo/src/services/openedx/client.ts
@@ -1,5 +1,9 @@
-import axios from "axios"
+import defaultAxios from "axios"
 import type { AxiosResponse } from "axios"
+
+const axios = defaultAxios.create({
+  withCredentials: true,
+})
 
 type CourseV2BlocksRequest = {
   blockUsageKey: string


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7090

### Description (What does it do?)
Include credentials in sandbox requests

### How can this be tested?

This could be tested locally with a local OpenEdx instance instead of the openedx proxy used by default.

If you want to test this locally, my suggestion is:
1. docker compose up
2. Go to http://ai.open.odl.local:8003/?tab=VideoGPT
3. Copy the network call to `/openedx_proxy/api/user/v1/me` as a `fetch`:
    <img width="728" alt="Screenshot 2025-04-24 at 2 30 53 PM" src="https://github.com/user-attachments/assets/4d25faff-fb9b-4c4a-bcae-1b91bc97db28" />
4. Paste it into the console at https://learn-ai-qa.ol.mit.edu/, changing the url to `
https://courses-qa.mitxonline.mit.edu/api/user/v1/me`. It should succeed. (200 not 401, either including your user data or indicating you're anonymous).