### PR TITLE
Option to override the default recommendation bot search url 

### DIFF
--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -28,6 +28,7 @@ def get_search_tool_metadata(thread_id: str, latest_state: TypedDict) -> str:
             content = json.loads(msg_content or {})
             metadata = {
                 "metadata": {
+                    "search_url": content.get("metadata", {}).get("search_url"),
                     "search_parameters": content.get("metadata", {}).get(
                         "parameters", []
                     ),

--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -252,6 +252,15 @@ class BaseChatbot(ABC):
         raise NotImplementedError
 
 
+class RecommendationAgentState(AgentState):
+    """
+    State for the recommendation bot. Passes search url
+    to the associated tool function.
+    """
+
+    search_url: Annotated[list[str], add]
+
+
 class ResourceRecommendationBot(BaseChatbot):
     """
     Chatbot that searches for learning resources in the MIT Learn catalog,
@@ -347,6 +356,20 @@ ANSWER QUESTIONS.
         thread_id = self.config["configurable"]["thread_id"]
         latest_state = await self.get_latest_history()
         return get_search_tool_metadata(thread_id, latest_state)
+
+    def create_agent_graph(self) -> CompiledGraph:
+        """
+        Generate a standard react agent graph for the recommendation agent.
+        Use the custom RecommendationAgentState to pass search_url
+        to the associated tool function.
+        """
+        return create_react_agent(
+            self.llm,
+            tools=self.tools,
+            checkpointer=self.checkpointer,
+            state_schema=RecommendationAgentState,
+            state_modifier=self.instructions,
+        )
 
 
 class SyllabusAgentState(AgentState):

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -163,10 +163,13 @@ async def test_recommendation_bot_tool(settings, mocker, search_results):
         "certification": True,
         "offered_by": ["xpro"],
         "limit": 5,
+        "state": {"search_url": [settings.AI_MIT_SEARCH_URL]},
     }
-    expected_results["metadata"]["parameters"] = search_parameters.copy()
     tool = chatbot.create_tools()[0]
     results = tool.invoke(search_parameters)
+    search_parameters.pop("state")
+    expected_results["metadata"]["parameters"] = search_parameters
+    expected_results["metadata"]["search_url"] = settings.AI_MIT_SEARCH_URL
     mock_post.assert_called_once_with(
         settings.AI_MIT_SEARCH_URL,
         params={"q": "physics", **search_parameters},
@@ -361,7 +364,8 @@ async def test_get_tool_metadata(mocker, mock_checkpointer):
                 "q": "main topics",
                 "resource_readable_id": "MITx+6.00.1x",
                 "collection_name": "vector512",
-            }
+            },
+            "search_url": "https://test.mit.edu/search2",
         },
         "results": [
             {
@@ -385,7 +389,11 @@ async def test_get_tool_metadata(mocker, mock_checkpointer):
                                 tool_args={"q": "main topics"},
                                 content=json.dumps(mock_tool_content),
                             ),
-                        ]
+                        ],
+                        "search_url": [
+                            "https://test.mit.edu/search0",
+                            "https://test.mit.edu/search1",
+                        ],
                     }
                 )
             ]
@@ -397,6 +405,9 @@ async def test_get_tool_metadata(mocker, mock_checkpointer):
     assert metadata == json.dumps(
         {
             "metadata": {
+                "search_url": mock_tool_content.get("metadata", {}).get(
+                    "search_url", []
+                ),
                 "search_parameters": mock_tool_content.get("metadata", {}).get(
                     "parameters", []
                 ),

--- a/ai_chatbots/consumers.py
+++ b/ai_chatbots/consumers.py
@@ -28,6 +28,7 @@ from ai_chatbots.constants import (
 from ai_chatbots.models import UserChatSession
 from ai_chatbots.serializers import (
     ChatRequestSerializer,
+    RecommendationChatRequestSerializer,
     SyllabusChatRequestSerializer,
     TutorChatRequestSerializer,
     VideoGPTRequestSerializer,
@@ -46,7 +47,7 @@ class BaseBotHttpConsumer(ABC, AsyncHttpConsumer, BaseThrottledAsyncConsumer):
     # Each bot consumer should define a unique ROOM_NAME
     ROOM_NAME = None
 
-    serializer_class = ChatRequestSerializer
+    serializer_class = RecommendationChatRequestSerializer
     headers_sent = False
     session_key = ""
 
@@ -353,8 +354,17 @@ class RecommendationBotHttpConsumer(BaseBotHttpConsumer):
     ROOM_NAME = ResourceRecommendationBot.__name__
     throttle_scope = "recommendation_bot"
 
+    def process_extra_state(self, data: dict) -> dict:
+        """Process extra state parameters if any"""
+        log.info("Processing extra state for rec bot: %s", data)
+        return {
+            "search_url": [data.get("search_url")],
+        }
+
     def create_chatbot(
-        self, serializer: ChatRequestSerializer, checkpointer: BaseCheckpointSaver
+        self,
+        serializer: RecommendationChatRequestSerializer,
+        checkpointer: BaseCheckpointSaver,
     ):
         """Return a ResourceRecommendationBot instance"""
         temperature = serializer.validated_data.pop("temperature", None)

--- a/ai_chatbots/consumers.py
+++ b/ai_chatbots/consumers.py
@@ -357,7 +357,7 @@ class RecommendationBotHttpConsumer(BaseBotHttpConsumer):
     def process_extra_state(self, data: dict) -> dict:
         """Process extra state parameters if any"""
         return {
-            "search_url": [data.get("search_url", settings.AI_MIT_SEARCH_URL)],
+            "search_url": [data.get("search_url") or settings.AI_MIT_SEARCH_URL],
         }
 
     def create_chatbot(

--- a/ai_chatbots/consumers.py
+++ b/ai_chatbots/consumers.py
@@ -356,9 +356,8 @@ class RecommendationBotHttpConsumer(BaseBotHttpConsumer):
 
     def process_extra_state(self, data: dict) -> dict:
         """Process extra state parameters if any"""
-        log.info("Processing extra state for rec bot: %s", data)
         return {
-            "search_url": [data.get("search_url")],
+            "search_url": [data.get("search_url", settings.AI_MIT_SEARCH_URL)],
         }
 
     def create_chatbot(

--- a/ai_chatbots/consumers_test.py
+++ b/ai_chatbots/consumers_test.py
@@ -117,8 +117,8 @@ async def test_recommend_agent_handle(  # noqa: PLR0913
     assert recommendation_consumer.bot.instructions == (
         instructions if instructions else ResourceRecommendationBot.INSTRUCTIONS
     )
-
-    mock_completion.assert_called_once_with(message, extra_state=None)
+    default_state = {"search_url": [settings.AI_MIT_SEARCH_URL]}
+    mock_completion.assert_called_once_with(message, extra_state=default_state)
     assert (
         mock_http_consumer_send.send_body.call_count
         == len(response.content.split(" ")) + 2

--- a/ai_chatbots/factories.py
+++ b/ai_chatbots/factories.py
@@ -17,6 +17,7 @@ from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 from ai_chatbots import models
 from ai_chatbots.chatbots import (
+    RecommendationAgentState,
     ResourceRecommendationBot,
     SyllabusAgentState,
     VideoGPTAgentState,
@@ -183,6 +184,16 @@ class AIMessageChunkFactory(BaseMessageFactory):
 
     class Meta:
         model = AIMessageChunk
+
+
+class RecommendationAgentStateFactory(factory.Factory):
+    """Factory for generating RecommendationAgent instances."""
+
+    messages = [factory.SubFactory(HumanMessageFactory)]
+    search_url = [factory.Faker("url")]
+
+    class Meta:
+        model = RecommendationAgentState
 
 
 class SyllabusAgentStateFactory(factory.Factory):

--- a/ai_chatbots/serializers.py
+++ b/ai_chatbots/serializers.py
@@ -1,5 +1,6 @@
 """Serializers for the ai_chatbots app"""
 
+from django.conf import settings
 from rest_framework import serializers
 
 from ai_chatbots.models import DjangoCheckpoint, LLMModel, UserChatSession
@@ -28,6 +29,16 @@ class ChatRequestSerializer(serializers.Serializer):
             err_msg = "You do not have permission to adjust the instructions."
             raise serializers.ValidationError(err_msg)
         return value
+
+
+class RecommendationChatRequestSerializer(ChatRequestSerializer):
+    """
+    Serializer for requests sent to the syllabus chatbot.
+    """
+
+    search_url = serializers.CharField(
+        required=False, allow_blank=False, default=settings.AI_MIT_SEARCH_URL
+    )
 
 
 class SyllabusChatRequestSerializer(ChatRequestSerializer):

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -114,9 +114,13 @@ class SearchToolSchema(pydantic.BaseModel):
             """,
     )
 
+    state: Annotated[dict, InjectedState] = Field(
+        description="The agent state, including the search url to use"
+    )
+
 
 @tool(args_schema=SearchToolSchema)
-def search_courses(q: str, **kwargs) -> str:
+def search_courses(q: str, state: Annotated[dict, InjectedState], **kwargs) -> str:
     """
     Query the MIT API for learning resources, and
     return simplified results as a JSON string
@@ -131,9 +135,10 @@ def search_courses(q: str, **kwargs) -> str:
         "certification": kwargs.get("certification"),
     }
     params.update({k: v for k, v in valid_params.items() if v is not None})
-    log.debug("Searching MIT API with params: %s", params)
+    search_url = state["search_url"][-1]
+    log.debug("Searching MIT API at %s with params: %s", search_url, params)
     try:
-        response = requests.get(settings.AI_MIT_SEARCH_URL, params=params, timeout=30)
+        response = requests.get(search_url, params=params, timeout=30)
         response.raise_for_status()
         raw_results = response.json().get("results", [])
         # Simplify the response to only include the main properties
@@ -168,7 +173,7 @@ def search_courses(q: str, **kwargs) -> str:
             simplified_results.append(simplified_result)
         full_output = {
             "results": simplified_results,
-            "metadata": {"parameters": params},
+            "metadata": {"search_url": search_url, "parameters": params},
         }
         return json.dumps(full_output)
     except requests.exceptions.RequestException:

--- a/env/frontend.env
+++ b/env/frontend.env
@@ -13,3 +13,7 @@ NEXT_PUBLIC_OPENEDX_PROXY_TARGET=https://courses-qa.mitxonline.mit.edu/
 NEXT_PUBLIC_OPENEDX_LOGIN_URL=https://rc.mitxonline.mit.edu/signin/
 OPENEDX_SESSION_COOKIE_NAME=mitxonline-qa-edx-lms-sessionid
 # OPENEDX_SESSION_COOKIE_VALUE=set-this-in-frontend.local.env
+
+
+NEXT_PUBLIC_MIT_SEARCH_ELASTIC_URL=${AI_MIT_SEARCH_ELASTIC_URL}
+NEXT_PUBLIC_MIT_SEARCH_VECTOR_URL=${AI_MIT_SEARCH_VECTOR_URL}

--- a/env/shared.env
+++ b/env/shared.env
@@ -15,3 +15,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
 CSRF_COOKIE_NAME=csrf-token
+
+
+AI_MIT_SEARCH_ELASTIC_URL=https://api.learn.mit.edu/api/v1/learning_resources_search/
+AI_MIT_SEARCH_VECTOR_URL=https://api.learn.mit.edu/api/v0/vector_learning_resources_search/

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -6,6 +6,7 @@ import Grid from "@mui/material/Grid2"
 import SelectModel from "./SelectModel"
 import React, { useMemo } from "react"
 import { getRequestOpts, useSearchParamSettings } from "./util"
+import SelectSearchURL from "./SelectSearchUrl"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -16,15 +17,19 @@ const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
 const RecommendationContent: React.FC = () => {
   const [settings, setSettings] = useSearchParamSettings({
     rec_model: "",
+    search_url: "",
   })
 
   const requestOpts = useMemo(
     () =>
       getRequestOpts({
         apiUrl: RECOMMENDATION_GPT_URL,
-        extraBody: { model: settings.rec_model },
+        extraBody: {
+          model: settings.rec_model,
+          search_url: settings.search_url,
+        },
       }),
-    [settings.rec_model],
+    [settings.rec_model, settings.search_url],
   )
 
   return (
@@ -56,6 +61,10 @@ const RecommendationContent: React.FC = () => {
           <SelectModel
             value={settings.rec_model}
             onChange={(e) => setSettings({ rec_model: e.target.value })}
+          />
+          <SelectSearchURL
+            value={settings.search_url}
+            onChange={(e) => setSettings({ search_url: e.target.value })}
           />
         </Grid>
       </Grid>

--- a/frontend-demo/src/app/(home)/SelectSearchUrl.tsx
+++ b/frontend-demo/src/app/(home)/SelectSearchUrl.tsx
@@ -1,0 +1,40 @@
+import MenuItem from "@mui/material/MenuItem"
+import TextField from "@mui/material/TextField"
+import type { TextFieldProps } from "@mui/material/TextField"
+
+const SelectSearchURL: React.FC<
+  TextFieldProps & {
+    value: string
+  }
+> = (props) => {
+  return (
+    <TextField
+      label="Search Type"
+      size="small"
+      margin="normal"
+      fullWidth
+      select
+      {...props}
+      /**
+       * Avoid passing an out-of-range value while the options are loading.
+       */
+      value={props.value}
+    >
+      <MenuItem value="">Search Type</MenuItem>
+      <MenuItem
+        key="traditional"
+        value={process.env.NEXT_PUBLIC_MIT_SEARCH_ELASTIC_URL}
+      >
+        Elasticsearch
+      </MenuItem>
+      <MenuItem
+        key="vector"
+        value={process.env.NEXT_PUBLIC_MIT_SEARCH_VECTOR_URL}
+      >
+        Vector
+      </MenuItem>
+    </TextField>
+  )
+}
+
+export default SelectSearchURL

--- a/frontend-demo/src/app/(home)/util.ts
+++ b/frontend-demo/src/app/(home)/util.ts
@@ -21,6 +21,7 @@ const getRequestOpts = <Body extends Record<string, unknown>>({
         message: messages[messages.length - 1].content,
         ...extraBody,
         model: extraBody.model ? extraBody.model : undefined,
+        search_url: extraBody.search_url ? extraBody.search_url : undefined,
       }
     },
   }

--- a/main/settings.py
+++ b/main/settings.py
@@ -581,9 +581,17 @@ CHANNEL_LAYERS = {
 
 # AI settings
 AI_DEBUG = get_bool("AI_DEBUG", False)  # noqa: FBT003
+AI_MIT_SEARCH_VECTOR_URL = get_string(
+    name="AI_MIT_SEARCH_VECTOR_URL",
+    default="https://api.learn.mit.edu/api/v0/vector_learning_resources_search/",
+)
+AI_MIT_SEARCH_ELASTIC_URL = get_string(
+    name="AI_MIT_SEARCH_ELASTIC_URL",
+    default="https://api.learn.mit.edu/api/v1/learning_resources_search/",
+)
 AI_MIT_SEARCH_URL = get_string(
     name="AI_MIT_SEARCH_URL",
-    default="https://api.learn.mit.edu/api/v1/learning_resources_search/",
+    default=AI_MIT_SEARCH_ELASTIC_URL,
 )
 AI_MIT_SEARCH_DETAIL_URL = get_string(
     name="AI_MIT_SEARCH_DETAIL_URL",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7171

### Description (What does it do?)
Adds search url to the agent state of the RecommendationBot and updates the sandbox UI to specify it.

### Screenshots (if appropriate):
![brave_screenshot_ai open odl local (2)](https://github.com/user-attachments/assets/1ee492c4-5a86-4d18-bc99-c205e03655dd)


### How can this be tested?
- Set `AI_DEBUG=True`
- With the network tab open, try the sandbox UI with all 3 search url options (none selected, elasticsearch, vector).  After each request, check the metadata at the end of the response for `search_url`, it should be the vector endpoint if you selected "Vector" otherwise it should be the elasticsearch endpoint.

### Additional Context
The default remains elasticsearch; if we decide the vector search provides better results, I'll create an ol-infrstructure PR to change it.



