### PR TITLE
Start new thread when changing model in sandbox

### DIFF
--- a/env/frontend.env
+++ b/env/frontend.env
@@ -12,7 +12,7 @@ NEXT_PUBLIC_OPENEDX_API_BASE_URL="/openedx_proxy/"
 # After logging in to the `NEXT_PUBLIC_OPENEDX_PROXY_TARGET` url, copy the value
 # of `OPENEDX_SESSION_COOKIE_NAME` cookie and set it to `OPENEDX_SESSION_COOKIE_VALUE`
 NEXT_PUBLIC_OPENEDX_PROXY_TARGET=https://courses-qa.mitxonline.mit.edu/
-NEXT_PUBLIC_OPENEDX_LOGIN_URL=https://rc.mitxonline.mit.edu/signin/
+NEXT_PUBLIC_OPENEDX_LOGIN_URL='https://courses-qa.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login'
 OPENEDX_SESSION_COOKIE_NAME=mitxonline-qa-edx-lms-sessionid
 # OPENEDX_SESSION_COOKIE_VALUE=set-this-in-frontend.local.env
 

--- a/frontend-demo/src/app/(home)/AssessmentContent.tsx
+++ b/frontend-demo/src/app/(home)/AssessmentContent.tsx
@@ -4,13 +4,14 @@ import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
 import Typography from "@mui/material/Typography"
 import Grid from "@mui/material/Grid2"
 import SelectModel from "./SelectModel"
-import { getRequestOpts, useSearchParamSettings } from "./util"
+import { useRequestOpts, useSearchParamSettings } from "./util"
 import { useV2Block } from "@/services/openedx"
 import OpenEdxLoginAlert from "./OpenedxLoginAlert"
 import OpenedxUnitSelectionForm from "./OpenedxUnitSelectionForm"
 import CircularProgress from "@mui/material/CircularProgress"
 import MetadataDisplay from "./MetadataDisplay"
 import { MathJaxContext } from "better-react-mathjax"
+import { Button } from "@mitodl/smoot-design"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = []
 const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
@@ -39,7 +40,7 @@ const AssessmentContent = () => {
     (key) => key !== vertical.data?.root,
   )
 
-  const requestOpts = getRequestOpts({
+  const { requestOpts, requestNewThread, threadCount } = useRequestOpts({
     apiUrl: ASSESSMENT_GPT_URL,
     extraBody: {
       model: settings.tutor_model,
@@ -49,11 +50,12 @@ const AssessmentContent = () => {
   })
   const isReady = vertical.isSuccess
 
+  const chatId = `assessment-gpt-${threadCount}`
   return (
     <>
       <Typography variant="h3">AssessmentGPT</Typography>
       <AiChatProvider
-        chatId="assessment-gpt"
+        chatId={chatId}
         initialMessages={INITIAL_MESSAGES}
         requestOpts={requestOpts}
       >
@@ -83,11 +85,21 @@ const AssessmentContent = () => {
               />
             )}
           </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
+          <Grid
+            size={{ xs: 12, md: 4 }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
+          >
             <OpenEdxLoginAlert />
             <SelectModel
               value={settings.tutor_model}
-              onChange={(e) => setSettings({ tutor_model: e.target.value })}
+              onChange={(e) => {
+                setSettings({ tutor_model: e.target.value })
+                requestNewThread()
+              }}
             />
             <OpenedxUnitSelectionForm
               selectedVertical={settings.tutor_vertical}
@@ -109,6 +121,9 @@ const AssessmentContent = () => {
               unitFilterType="problem"
               unitLabel="Problem"
             />
+            <Button variant="secondary" onClick={requestNewThread}>
+              Start new thread
+            </Button>
           </Grid>
           <Grid size={{ xs: 12 }}>
             <MetadataDisplay />

--- a/frontend-demo/src/app/(home)/AssessmentContent.tsx
+++ b/frontend-demo/src/app/(home)/AssessmentContent.tsx
@@ -40,7 +40,7 @@ const AssessmentContent = () => {
     (key) => key !== vertical.data?.root,
   )
 
-  const { requestOpts, requestNewThread, threadCount } = useRequestOpts({
+  const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
     apiUrl: ASSESSMENT_GPT_URL,
     extraBody: {
       model: settings.tutor_model,
@@ -50,7 +50,7 @@ const AssessmentContent = () => {
   })
   const isReady = vertical.isSuccess
 
-  const chatId = `assessment-gpt-${threadCount}`
+  const chatId = `assessment-gpt-${chatSuffix}`
   return (
     <>
       <Typography variant="h3">AssessmentGPT</Typography>

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -4,10 +4,11 @@ import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
 import Typography from "@mui/material/Typography"
 import Grid from "@mui/material/Grid2"
 import SelectModel from "./SelectModel"
-import React, { useMemo } from "react"
-import { getRequestOpts, useSearchParamSettings } from "./util"
+import React from "react"
+import { useRequestOpts, useSearchParamSettings } from "./util"
 import SelectSearchURL from "./SelectSearchUrl"
 import MetadataDisplay from "./MetadataDisplay"
+import { Button } from "@mitodl/smoot-design"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -21,17 +22,15 @@ const RecommendationContent: React.FC = () => {
     search_url: "",
   })
 
-  const requestOpts = useMemo(
-    () =>
-      getRequestOpts({
-        apiUrl: RECOMMENDATION_GPT_URL,
-        extraBody: {
-          model: settings.rec_model,
-          search_url: settings.search_url,
-        },
-      }),
-    [settings.rec_model, settings.search_url],
-  )
+  const { requestOpts, requestNewThread, threadCount } = useRequestOpts({
+    apiUrl: RECOMMENDATION_GPT_URL,
+    extraBody: {
+      model: settings.rec_model,
+      search_url: settings.search_url,
+    },
+  })
+
+  const chatId = `recommendation-gpt-${threadCount}`
 
   return (
     <>
@@ -43,7 +42,7 @@ const RecommendationContent: React.FC = () => {
       >
         RecommendationGPT
       </Typography>
-      <AiChatProvider chatId="recommendation-gpt" requestOpts={requestOpts}>
+      <AiChatProvider chatId={chatId} requestOpts={requestOpts}>
         <Grid container spacing={2} sx={{ padding: 2 }}>
           <Grid
             size={{ xs: 12, md: 8 }}
@@ -56,16 +55,26 @@ const RecommendationContent: React.FC = () => {
           </Grid>
           <Grid
             size={{ xs: 12, md: 4 }}
-            sx={{ display: "flex", flexDirection: "column", gap: "16px" }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
           >
             <SelectModel
               value={settings.rec_model}
-              onChange={(e) => setSettings({ rec_model: e.target.value })}
+              onChange={(e) => {
+                setSettings({ rec_model: e.target.value })
+                requestNewThread()
+              }}
             />
             <SelectSearchURL
               value={settings.search_url}
               onChange={(e) => setSettings({ search_url: e.target.value })}
             />
+            <Button variant="secondary" onClick={requestNewThread}>
+              Start new thread
+            </Button>
           </Grid>
           <Grid size={{ xs: 12 }}>
             <MetadataDisplay />

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -22,7 +22,7 @@ const RecommendationContent: React.FC = () => {
     search_url: "",
   })
 
-  const { requestOpts, requestNewThread, threadCount } = useRequestOpts({
+  const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
     apiUrl: RECOMMENDATION_GPT_URL,
     extraBody: {
       model: settings.rec_model,
@@ -30,7 +30,7 @@ const RecommendationContent: React.FC = () => {
     },
   })
 
-  const chatId = `recommendation-gpt-${threadCount}`
+  const chatId = `recommendation-gpt-${chatSuffix}`
 
   return (
     <>

--- a/frontend-demo/src/app/(home)/SyllabusContent.tsx
+++ b/frontend-demo/src/app/(home)/SyllabusContent.tsx
@@ -6,13 +6,14 @@ import Typography from "@mui/material/Typography"
 import Grid from "@mui/material/Grid2"
 import TextField from "@mui/material/TextField"
 import SelectModel from "./SelectModel"
-import { getRequestOpts, useSearchParamSettings } from "./util"
+import { useRequestOpts, useSearchParamSettings } from "./util"
 import { useQuery, UseQueryResult } from "@tanstack/react-query"
 import { learningResourcesQueries } from "@/services/learn"
 import { LearningResource } from "@mitodl/open-api-axios/v1"
 import { useEffect, useState } from "react"
 import CircularProgress from "@mui/material/CircularProgress"
 import MetadataDisplay from "./MetadataDisplay"
+import { Button } from "@mitodl/smoot-design"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -102,7 +103,7 @@ const SyllabusContent = () => {
     enabled: !!resourceId,
   })
 
-  const requestOpts = getRequestOpts({
+  const { requestOpts, threadCount, requestNewThread } = useRequestOpts({
     apiUrl: SYLLABUS_GPT_URL,
     extraBody: {
       model: settings.syllabus_model,
@@ -111,10 +112,11 @@ const SyllabusContent = () => {
   })
 
   const isReady = resource.isSuccess
+  const chatId = `syllabus-gpt-${threadCount}`
   return (
     <>
       <Typography variant="h3">SyllabusGPT</Typography>
-      <AiChatProvider chatId="syllabus-gpt" requestOpts={requestOpts}>
+      <AiChatProvider chatId={chatId} requestOpts={requestOpts}>
         <Grid container spacing={2} sx={{ padding: 2 }}>
           <Grid
             size={{ xs: 12, md: 8 }}
@@ -138,10 +140,20 @@ const SyllabusContent = () => {
               />
             )}
           </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
+          <Grid
+            size={{ xs: 12, md: 4 }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
+          >
             <SelectModel
               value={settings.syllabus_model}
-              onChange={(e) => setSettings({ syllabus_model: e.target.value })}
+              onChange={(e) => {
+                setSettings({ syllabus_model: e.target.value })
+                requestNewThread()
+              }}
             />
             <TextField
               size="small"
@@ -158,6 +170,9 @@ const SyllabusContent = () => {
               error={!!resourceParseError || resource.isError}
               helperText={getResourceHelpText(resourceParseError, resource)}
             />
+            <Button variant="secondary" onClick={requestNewThread}>
+              Start new thread
+            </Button>
           </Grid>
           <Grid size={{ xs: 12 }}>
             <MetadataDisplay />

--- a/frontend-demo/src/app/(home)/SyllabusContent.tsx
+++ b/frontend-demo/src/app/(home)/SyllabusContent.tsx
@@ -103,7 +103,7 @@ const SyllabusContent = () => {
     enabled: !!resourceId,
   })
 
-  const { requestOpts, threadCount, requestNewThread } = useRequestOpts({
+  const { requestOpts, chatSuffix, requestNewThread } = useRequestOpts({
     apiUrl: SYLLABUS_GPT_URL,
     extraBody: {
       model: settings.syllabus_model,
@@ -112,7 +112,7 @@ const SyllabusContent = () => {
   })
 
   const isReady = resource.isSuccess
-  const chatId = `syllabus-gpt-${threadCount}`
+  const chatId = `syllabus-gpt-${chatSuffix}`
   return (
     <>
       <Typography variant="h3">SyllabusGPT</Typography>

--- a/frontend-demo/src/app/(home)/VideoContent.tsx
+++ b/frontend-demo/src/app/(home)/VideoContent.tsx
@@ -4,7 +4,7 @@ import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
 import Typography from "@mui/material/Typography"
 import Grid from "@mui/material/Grid2"
 import SelectModel from "./SelectModel"
-import { getRequestOpts, useSearchParamSettings } from "./util"
+import { useRequestOpts, useSearchParamSettings } from "./util"
 
 import { useQuery } from "@tanstack/react-query"
 import OpenEdxLoginAlert from "./OpenedxLoginAlert"
@@ -17,6 +17,7 @@ import OpenedxUnitSelectionForm from "./OpenedxUnitSelectionForm"
 import { ContentFile } from "@mitodl/open-api-axios/v1"
 import { CircularProgress } from "@mui/material"
 import MetadataDisplay from "./MetadataDisplay"
+import { Button } from "@mitodl/smoot-design"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = []
 const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
@@ -128,7 +129,7 @@ const VideoCntent = () => {
     }
   }, [videoContenfiles])
 
-  const requestOpts = getRequestOpts({
+  const { requestOpts, threadCount, requestNewThread } = useRequestOpts({
     apiUrl: VIDEO_GPT_URL,
     extraBody: {
       model: settings.video_model,
@@ -137,11 +138,12 @@ const VideoCntent = () => {
     },
   })
   const isReady = !!transcriptBlockId
+  const chatId = `video-gpt-${threadCount}`
   return (
     <>
       <Typography variant="h3">VideoGPT</Typography>
       <AiChatProvider
-        chatId="video-gpt"
+        chatId={chatId}
         initialMessages={INITIAL_MESSAGES}
         requestOpts={requestOpts}
       >
@@ -179,7 +181,10 @@ const VideoCntent = () => {
             <OpenEdxLoginAlert />
             <SelectModel
               value={settings.video_model}
-              onChange={(e) => setSettings({ video_model: e.target.value })}
+              onChange={(e) => {
+                setSettings({ video_model: e.target.value })
+                requestNewThread()
+              }}
             />
             <OpenedxUnitSelectionForm
               selectedVertical={settings.video_vertical}
@@ -205,6 +210,9 @@ const VideoCntent = () => {
             {transcriptError && (
               <Alert severity="error">{transcriptError}</Alert>
             )}
+            <Button variant="secondary" onClick={requestNewThread}>
+              Start new thread
+            </Button>
           </Grid>
           <Grid size={{ xs: 12 }}>
             <MetadataDisplay />

--- a/frontend-demo/src/app/(home)/VideoContent.tsx
+++ b/frontend-demo/src/app/(home)/VideoContent.tsx
@@ -129,7 +129,7 @@ const VideoCntent = () => {
     }
   }, [videoContenfiles])
 
-  const { requestOpts, threadCount, requestNewThread } = useRequestOpts({
+  const { requestOpts, chatSuffix, requestNewThread } = useRequestOpts({
     apiUrl: VIDEO_GPT_URL,
     extraBody: {
       model: settings.video_model,
@@ -138,7 +138,7 @@ const VideoCntent = () => {
     },
   })
   const isReady = !!transcriptBlockId
-  const chatId = `video-gpt-${threadCount}`
+  const chatId = `video-gpt-${chatSuffix}`
   return (
     <>
       <Typography variant="h3">VideoGPT</Typography>

--- a/frontend-demo/src/app/(home)/util.ts
+++ b/frontend-demo/src/app/(home)/util.ts
@@ -1,6 +1,6 @@
 import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { useSearchParams } from "next/navigation"
-import { useMemo, useRef, useState } from "react"
+import { useId, useMemo, useRef, useState } from "react"
 
 /**
  * Convenience for AiChat component to compute requestOpts settings
@@ -34,9 +34,9 @@ const getRequestOpts = <Body extends Record<string, unknown>>({
  *
  * When the requestNewThread function is called, it will:
  * 1. configure the next message sent to chatbot to clear history
- * 2. increment the threadCount state variable
+ * 2. return a new chatSuffix to be used in the AiChat component
  *
- * Incrementing the threadCount variable is to facilitate resetting the state
+ * Incrementing the chatSuffix variable is to facilitate resetting the state
  * of the AiChat component.
  */
 const useRequestOpts = <Body extends Record<string, unknown>>({
@@ -48,7 +48,7 @@ const useRequestOpts = <Body extends Record<string, unknown>>({
 }): {
   requestOpts: AiChatProps["requestOpts"]
   requestNewThread: () => void
-  threadCount: number
+  chatSuffix: string
 } => {
   const clearHistoryRef = useRef(false)
   const [threadCount, setThreadCount] = useState(0)
@@ -74,7 +74,9 @@ const useRequestOpts = <Body extends Record<string, unknown>>({
     clearHistoryRef.current = true
     setThreadCount((count) => count + 1)
   }
-  return { requestOpts, requestNewThread, threadCount }
+  const id = useId()
+  const chatSuffix = `${id}-${threadCount}`
+  return { requestOpts, requestNewThread, chatSuffix }
 }
 
 /**


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7231

### Description (What does it do?)
This PR makes it so:
1. A new thread is started when user changes AI model OR a new thread is started when user clicks "Start new thread"
2. The visible chat history clears when (1) occurs.
    - **NOTE:** For resource-dependent chats (e.g., syllabus bot) changing the resource also creates a new thread. However, this does not clear the visible chat history right now.
        - @Ferdi we could clear the visible chat history in this case if desirable. My rationale was that leaving it visible makes it easier to compare quality of responses.

However, there is currently no way to select a previously active thread.

### Screenshots (if appropriate):


https://github.com/user-attachments/assets/3b32d6e3-6085-4c80-9291-381e0ce10198



### How can this be tested?
1. Visit http://ai.open.odl.local:8003/ and select any tab (video/problem tabs require you to set `OPENEDX_SESSION_COOKIE_VALUE` in `frontend.local.env` if using openedx proxy, which is the default).
2. Open your network tab
3. Then, my recommendation is:
    1. **Message 1a**: Send a message to the chatbot, like "abcdefgh"
    2.  **Message 1b**: Ask the chatbot "What is the last thing I said to you"
        - It should say "abcdefgh" or whatever
    4. **Message 1c**: Send a mesage like "12345678" to the chatbot".
    5. Change the model OR click "start new thread". Try both methods.
    6. **Message 2a**:  Ask the chatbot "What is the last thing I said to 
        - it should express ignorance of your last message.
    7. **Message 2b**: Send it another message 
4. In your network tab, double check the request cookies on `[1a, 1b, 1c]` all have the same thread id, `[2a, 2b]` have the same thread id, but the 1s and the 2s have different thread ids. Relevant cookie names are human readable, e.g., `ResourceRecommendationBot_ai_threads_anon`
