### PR TITLE
allow newlines in display math replacement

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -563,6 +563,10 @@ class TutorBot(BaseChatbot):
             log.exception("Error running AI agent")
 
 
+INLINE_MATH_REGEX = re.compile(r"\\\((.*?)\\\)")
+DISPLAY_MATH_REGEX = re.compile(r"\\\[(.*?)\\\]", re.DOTALL)
+
+
 # react-markdown expects Mathjax deliminators to be $...$ or $$...$$
 # the prompt for the tutorbot asks for Mathjax tags with $ format but
 # the LLM does not get it right all the time
@@ -573,8 +577,8 @@ def replace_math_tags(input_string):
     Replace instances of \(...\) and \[...\] Mathjax tags with $...$
     and $$...$$ tags.
     """
-    input_string = re.sub(r"\\\((.*?)\\\)", r"$\1$", input_string)
-    return re.sub(r"\\\[(.*?)\\\]", r"$$\1$$", input_string)
+    input_string = re.sub(INLINE_MATH_REGEX, r"$\1$", input_string)
+    return re.sub(DISPLAY_MATH_REGEX, r"$$\1$$", input_string)
 
 
 def get_problem_from_edx_block(edx_module_id: str, block_siblings: list[str]):

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -22,6 +22,7 @@ from ai_chatbots.chatbots import (
     VideoGPTBot,
     get_history,
     get_problem_from_edx_block,
+    replace_math_tags,
 )
 from ai_chatbots.checkpointers import AsyncDjangoSaver
 from ai_chatbots.conftest import MockAsyncIterator
@@ -747,3 +748,34 @@ async def test_bad_request(mocker, mock_checkpointer):
     async for _ in chatbot.get_completion("hello"):
         chatbot.agent.astream.assert_called_once()
         mock_log.assert_called_once_with("Bad request error")
+
+
+def test_math_replacements():
+    """Test math replacement for tutor bot"""
+    input_text = r"""Hello \(E=mc^2\) and \(a^2 + b^2 = c^2\). Also
+
+\[
+F = ma
+\]
+
+and
+
+\[ PV = NkT \]
+
+Bye now.
+"""
+
+    expected_output = r"""Hello $E=mc^2$ and $a^2 + b^2 = c^2$. Also
+
+$$
+F = ma
+$$
+
+and
+
+$$ PV = NkT $$
+
+Bye now.
+"""
+    output_text = replace_math_tags(input_text)
+    assert output_text == expected_output


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7298

### Description (What does it do?)
Allows newlines during display math replacement.

### How can this be tested?
