### PR TITLE
Ab/test api changes for hiding content files

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -10,7 +10,6 @@ from typing import Annotated, Any, Optional
 from uuid import uuid4
 
 import posthog
-import requests
 from channels.db import database_sync_to_async
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -41,7 +40,7 @@ from ai_chatbots import tools
 from ai_chatbots.api import CustomSummarizationNode, get_search_tool_metadata
 from ai_chatbots.models import TutorBotOutput
 from ai_chatbots.prompts import PROMPT_MAPPING
-from ai_chatbots.utils import get_django_cache
+from ai_chatbots.utils import get_django_cache, request_with_token
 
 log = logging.getLogger(__name__)
 
@@ -612,7 +611,8 @@ def get_problem_from_edx_block(edx_module_id: str, block_siblings: list[str]):
 
     api_url = settings.AI_MIT_CONTENTFILE_URL
     params = {"edx_module_id": block_siblings}
-    response = requests.get(api_url, params=params, timeout=10)
+
+    response = request_with_token(api_url, params, timeout=10)
 
     response = response.json()
 

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -343,6 +343,7 @@ async def test_syllabus_bot_tool(
 ):
     """The SyllabusBot tool should call the correct tool"""
     settings.AI_MIT_CONTENT_SEARCH_LIMIT = 5
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
     retained_attributes = [
         "run_title",
         "chunk_content",
@@ -374,6 +375,7 @@ async def test_syllabus_bot_tool(
     mock_post.assert_called_once_with(
         settings.AI_MIT_SYLLABUS_URL,
         params=search_parameters,
+        headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
         timeout=30,
     )
     assert_json_equal(json.loads(results), expected_results)
@@ -717,6 +719,7 @@ async def test_video_gpt_bot_tool(
 ):
     """The VideoGPTBot should call the correct tool"""
     settings.AI_MIT_TRANSCRIPT_SEARCH_LIMIT = 2
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
     retained_attributes = [
         "chunk_content",
     ]
@@ -750,6 +753,7 @@ async def test_video_gpt_bot_tool(
     mock_post.assert_called_once_with(
         settings.AI_MIT_VIDEO_TRANSCRIPT_URL,
         params=search_parameters,
+        headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
         timeout=30,
     )
     assert_json_equal(json.loads(results), expected_results)

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -12,7 +12,7 @@ from langgraph.prebuilt import InjectedState
 from pydantic import Field
 
 from ai_chatbots.constants import LearningResourceType, OfferedBy
-from ai_chatbots.utils import enum_zip
+from ai_chatbots.utils import enum_zip, request_with_token
 
 log = logging.getLogger(__name__)
 
@@ -241,7 +241,7 @@ def search_content_files(
         params["collection_name"] = collection_name
     log.debug("Searching MIT content API with params: %s", params)
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = request_with_token(url, params, timeout=30)
         response.raise_for_status()
         raw_results = response.json().get("results", [])
         # Simplify the response to only include the main properties
@@ -279,7 +279,7 @@ def get_video_transcript_chunk(q: str, state: Annotated[dict, InjectedState]) ->
 
     log.debug("Searching MIT API with params: %s", params)
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = request_with_token(url, params, timeout=30)
         response.raise_for_status()
         raw_results = response.json().get("results", [])
         # Simplify the response to only include the main properties

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -120,6 +120,7 @@ def test_search_content_files(  # noqa: PLR0913
     """Test that the search_courses tool returns expected results w/expected params."""
     settings.AI_MIT_SYLLABUS_URL = search_url
     settings.AI_MIT_CONTENT_SEARCH_LIMIT = limit
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
     expected_params = {
         "q": "main topics",
         "limit": limit,
@@ -130,6 +131,9 @@ def test_search_content_files(  # noqa: PLR0913
         search_content_files.invoke({"q": "main topics", "state": syllabus_agent_state})
     )
     mock_get_resources.assert_called_once_with(
-        search_url, params=expected_params, timeout=30
+        search_url,
+        params=expected_params,
+        headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
+        timeout=30,
     )
     assert len(results["results"]) == len(search_results["results"])

--- a/ai_chatbots/urls.py
+++ b/ai_chatbots/urls.py
@@ -1,6 +1,6 @@
 """Standard urls for ai_chatbots app"""
 
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from rest_framework.routers import SimpleRouter
 
 from ai_chatbots import views
@@ -19,6 +19,15 @@ router.register(
 router.register(r"llm_models", views.LLMModelViewSet, basename="llm_models")
 
 app_name = "ai"
+v0_urls = [
+    *router.urls,
+    path(
+        r"get_transcript_edx_module_id/",
+        views.GetTranscriptBlockId.as_view(),
+        name="get_transcript_edx_module_id",
+    ),
+]
+
 urlpatterns = [
-    re_path(r"^api/v0/", include((router.urls, "v0"))),
+    re_path(r"^api/v0/", include((v0_urls, "v0"))),
 ]

--- a/ai_chatbots/utils.py
+++ b/ai_chatbots/utils.py
@@ -3,6 +3,7 @@
 import logging
 from enum import Enum
 
+import requests
 from django.conf import settings
 from django.core.cache import BaseCache, caches
 from named_enum import ExtendedEnum
@@ -37,3 +38,12 @@ def get_django_cache() -> BaseCache:
     if settings.CELERY_BROKER_URL:
         return caches["redis"]
     return caches["default"]
+
+
+def request_with_token(url, params, timeout: int = 30):
+    return requests.get(
+        url,
+        params=params,
+        headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
+        timeout=timeout,
+    )

--- a/ai_chatbots/views_test.py
+++ b/ai_chatbots/views_test.py
@@ -13,6 +13,7 @@ from ai_chatbots.factories import (
 )
 from ai_chatbots.models import LLMModel
 from ai_chatbots.serializers import ChatMessageSerializer, UserChatSessionSerializer
+from ai_chatbots.views import get_transcript_block_id
 from main.factories import UserFactory
 from main.test_utils import assert_json_equal
 
@@ -177,3 +178,14 @@ def test_llm_model_viewset_enabled_only(client):
     assert disabled_model.litellm_id not in [
         model["litellm_id"] for model in response.json()
     ]
+
+
+def test_get_transcript_block_id():
+    """Test that get_transcript_block_id returns the transcript block ID correctly"""
+    contentfile = {
+        "edx_module_id": "block-v1:MITxT+3.012Sx+3T2024+type@video+block@ab8c1a02e9804e75aff98835dd03c28d",
+        "content": '<video url_name="ab8c1a02e9804e75aff98835dd03c28d" sub="" transcripts="{&quot;en&quot;: &quot;df9493c5-4765-4b0c-a7bb-7ea732fea90e-en.srt&quot;}" display_name="State of Matter and Bonding" download_track="true" download_video="true" edx_video_id="df9493c5-4765-4b0c-a7bb-7ea732fea90e" html5_sources="[]" youtube_id_1_0="">\n  <video_asset client_video_id="3012_State_of_Matter_and_Bonding.mp4" duration="0.0" image="">\n    <encoded_video profile="hls" url="https://d3tsb3m56iwvoq.cloudfront.net/transcoded/51371d122b294c0ab27df648cf6068ca/video__index.m3u8" file_size="0" bitrate="0"/>\n    <transcripts>\n      <transcript language_code="en" file_format="srt" provider="Custom"/>\n    </transcripts>\n  </video_asset>\n  <transcript language="en" src="df9493c5-4765-4b0c-a7bb-7ea732fea90e-en.srt"/>\n</video>',
+    }
+
+    expected_block_id = "asset-v1:MITxT+3.012Sx+3T2024+type@asset+block@df9493c5-4765-4b0c-a7bb-7ea732fea90e-en.srt"
+    assert get_transcript_block_id(contentfile) == expected_block_id

--- a/frontend-demo/api/src/generated/v0/api.ts
+++ b/frontend-demo/api/src/generated/v0/api.ts
@@ -1508,6 +1508,181 @@ export class ChatSessionsApi extends BaseAPI {
 }
 
 /**
+ * GetTranscriptEdxModuleIdApi - axios parameter creator
+ * @export
+ */
+export const GetTranscriptEdxModuleIdApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * API view to get the transcript block ID from edx block for a cotentfile.
+     * @param {string} edx_module_id edx_module_id of the video content file
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTranscriptEdxModuleIdRetrieve: async (
+      edx_module_id: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'edx_module_id' is not null or undefined
+      assertParamExists(
+        "getTranscriptEdxModuleIdRetrieve",
+        "edx_module_id",
+        edx_module_id,
+      )
+      const localVarPath = `/api/v0/get_transcript_edx_module_id/`.replace(
+        `{${"edx_module_id"}}`,
+        encodeURIComponent(String(edx_module_id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * GetTranscriptEdxModuleIdApi - functional programming interface
+ * @export
+ */
+export const GetTranscriptEdxModuleIdApiFp = function (
+  configuration?: Configuration,
+) {
+  const localVarAxiosParamCreator =
+    GetTranscriptEdxModuleIdApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * API view to get the transcript block ID from edx block for a cotentfile.
+     * @param {string} edx_module_id edx_module_id of the video content file
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getTranscriptEdxModuleIdRetrieve(
+      edx_module_id: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.getTranscriptEdxModuleIdRetrieve(
+          edx_module_id,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap[
+          "GetTranscriptEdxModuleIdApi.getTranscriptEdxModuleIdRetrieve"
+        ]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * GetTranscriptEdxModuleIdApi - factory interface
+ * @export
+ */
+export const GetTranscriptEdxModuleIdApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = GetTranscriptEdxModuleIdApiFp(configuration)
+  return {
+    /**
+     * API view to get the transcript block ID from edx block for a cotentfile.
+     * @param {GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTranscriptEdxModuleIdRetrieve(
+      requestParameters: GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .getTranscriptEdxModuleIdRetrieve(
+          requestParameters.edx_module_id,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for getTranscriptEdxModuleIdRetrieve operation in GetTranscriptEdxModuleIdApi.
+ * @export
+ * @interface GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest
+ */
+export interface GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest {
+  /**
+   * edx_module_id of the video content file
+   * @type {string}
+   * @memberof GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieve
+   */
+  readonly edx_module_id: string
+}
+
+/**
+ * GetTranscriptEdxModuleIdApi - object-oriented interface
+ * @export
+ * @class GetTranscriptEdxModuleIdApi
+ * @extends {BaseAPI}
+ */
+export class GetTranscriptEdxModuleIdApi extends BaseAPI {
+  /**
+   * API view to get the transcript block ID from edx block for a cotentfile.
+   * @param {GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof GetTranscriptEdxModuleIdApi
+   */
+  public getTranscriptEdxModuleIdRetrieve(
+    requestParameters: GetTranscriptEdxModuleIdApiGetTranscriptEdxModuleIdRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return GetTranscriptEdxModuleIdApiFp(this.configuration)
+      .getTranscriptEdxModuleIdRetrieve(
+        requestParameters.edx_module_id,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
  * LlmModelsApi - axios parameter creator
  * @export
  */

--- a/main/settings.py
+++ b/main/settings.py
@@ -654,6 +654,10 @@ AI_MIT_CONTENTFILE_URL = get_string(
     name="AI_MIT_CONTENTFILE_URL",
     default="https://api.learn.mit.edu/api/v1/contentfiles/",
 )
+LEARN_ACCESS_TOKEN = get_string(
+    name="LEARN_ACCESS_TOKEN",
+    default="",
+)
 AI_MIT_SEARCH_LIMIT = get_int(name="AI_MIT_SEARCH_LIMIT", default=10)
 AI_MIT_CONTENT_SEARCH_LIMIT = get_int(name="AI_MIT_CONTENT_SEARCH_LIMIT", default=20)
 AI_MIT_TRANSCRIPT_SEARCH_LIMIT = get_int(name="AI_MIT_CONTENT_SEARCH_LIMIT", default=5)

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -164,6 +164,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedChatMessageList'
           description: ''
+  /api/v0/get_transcript_edx_module_id/:
+    get:
+      operationId: get_transcript_edx_module_id_retrieve
+      description: API view to get the transcript block ID from edx block for a cotentfile.
+      parameters:
+      - in: path
+        name: edx_module_id
+        schema:
+          type: string
+        description: edx_module_id of the video content file
+        required: true
+      tags:
+      - get_transcript_edx_module_id
+      security:
+      - {}
+      responses:
+        '200':
+          description: Transcript block ID
+        '500':
+          description: Error retrieving transcript block ID
   /api/v0/llm_models/:
     get:
       operationId: llm_models_list

--- a/poetry.lock
+++ b/poetry.lock
@@ -7908,4 +7908,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.13.3"
-content-hash = "a98fede1b265fce2c67b8ef07cd4cce62025dd67090c622941fc50c5587c948f"
+content-hash = "5d34df44d4579f9dd65dbbb83025a1a578cdeced98fd98b8eba06cb3c4111937"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ starlette = "0.46.2"
 ulid-py = "^1.0.0"
 uvicorn = {extras = ["standard"], version = "^0.34.0"}
 langmem = "^0.0.27"
+beautifulsoup4 = "^4.13.4"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6459

### Description (What does it do?)
It updates learn ai to use the auth changes in https://github.com/mitodl/mit-learn/pull/2249

### How can this be tested?
Run the code in this branch and verify that all four chatbots behave normally

In your local learn instance checkout the branch in https://github.com/mitodl/mit-learn/pull/2249. 
Log in as an admin
Go to http://api.open.odl.local:8065/admin/users/user/
Create a new user called "learn_ai_user" and add "content_file_viewers" to the user's groups
Go to http://api.open.odl.local:8065/admin/oauth2_provider/accesstoken/ and add a new access token for user "learn_ai_user" 

Make sure the test courses used in learn ai are populated
Run
docker-compose run web ./manage.py backpopulate_mitxonline_data
Find the resource id for "Structure of Materials"
docker-compose run web ./manage.py backpopulate_mitxonline_files --resource-id id
docker-compose run web ./manage.py generate_embeddings  --resource-id id
docker-compose run web ./manage.py generate_summary_flashcards  --resource-id id



In shared.env in learn-ai set
AI_MIT_CONTENTFILE_URL=http://host.docker.internal:8065/api/v1/contentfiles
AI_MIT_SEARCH_VECTOR_URL=http://host.docker.internal:8065/api/v0/vector_learning_resources_search/
AI_MIT_SEARCH_ELASTIC_URL=http://host.docker.internal:8065/api/v1/learning_resources_search/
AI_MIT_SEARCH_URL=http://host.docker.internal:8065/api/v1/learning_resources_search/
AI_MIT_SYLLABUS_URL="http://host.docker.internal:8065/api/v0/vector_content_files_search/"
AI_MIT_VIDEO_TRANSCRIPT_URL="http://host.docker.internal:8065/api/v0/vector_content_files_search/"
AI_MIT_SEARCH_DETAIL_URL=http://host.docker.internal:8062/?resource=
LEARN_ACCESS_TOKEN=whatever the access token for "learn_ai_user" is


in fronted.env set
NEXT_PUBLIC_MIT_LEARN_API_BASE_URL="http://host.docker.internal:8065"
NEXT_PUBLIC_MIT_LEARN_APP_BASE_URL="http://host.docker.internal:8062"



Verify that all the recommendation bot works as expected. You should see calls in the logs of your local open instance

Go to the syllabus bot. Change the id of the resource to your local id of "Structure of Materials". The syllabus bot should work

Go to the video bot verify that it works

Go to the tutor bot verify that it works




