### PR TITLE
Adjust chatbot system prompts to tell the LLM its name is Tim

### DIFF
--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -44,6 +44,7 @@ pytestmark = pytest.mark.django_db
 def mock_settings(settings):
     """Langsmith API should be blank for most tests"""
     os.environ["LANGSMITH_API_KEY"] = ""
+    os.environ["LANGSMITH_TRACING"] = ""
     settings.LANGSMITH_API_KEY = ""
     return settings
 

--- a/ai_chatbots/management/commands/update_prompt.py
+++ b/ai_chatbots/management/commands/update_prompt.py
@@ -1,0 +1,120 @@
+"""Management command for updating a prompt's text content from the command line."""
+
+import os
+import sys
+from pathlib import Path
+
+from django.core.management import BaseCommand
+from langchain_core.prompts import ChatPromptTemplate
+from langsmith import Client as LangsmithClient
+from langsmith.utils import LangSmithNotFoundError
+from open_learning_ai_tutor.prompts import (
+    TUTOR_PROMPT_MAPPING,
+    assessment_prompt_mapping,
+    intent_prompt_mapping,
+    prompt_env_key,
+)
+
+from ai_chatbots.prompts import PROMPT_MAPPING
+from ai_chatbots.utils import get_django_cache
+
+
+class Command(BaseCommand):
+    """Update a single langsmith prompt key with a new value."""
+
+    help = "Clear the prompt cache."
+    cache = get_django_cache()
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--prompt",
+            dest="prompt_name",
+            required=True,
+            help="Specify the prompt to update",
+        )
+        parser.add_argument(
+            "--content",
+            dest="content",
+            required=False,
+            help="Specify the prompt text",
+        )
+        parser.add_argument(
+            "--contentfile",
+            dest="contentfile",
+            required=False,
+            help="Specify the file containing prompt text",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Clear the prompt cache."""
+        prompt_name = options["prompt_name"]
+        prompt_value = options["content"]
+        prompt_file_value = options["contentfile"]
+
+        if prompt_file_value and prompt_value:
+            self.stdout.error(
+                "Please provide either --content or --contentfile, not both."
+            )
+            return 1
+
+        if prompt_file_value:
+            with Path.open(prompt_file_value, "r") as file:
+                prompt_value = file.read()
+
+        if not prompt_value and not prompt_file_value:
+            for mapping in (
+                PROMPT_MAPPING,
+                TUTOR_PROMPT_MAPPING,
+                assessment_prompt_mapping,
+                intent_prompt_mapping,
+            ):
+                if prompt_name in mapping:
+                    prompt_value = mapping[prompt_name]
+                    break
+        if not prompt_value:
+            self.stderr.write(
+                f"Default value for prompt '{prompt_name}' was not found."
+            )
+            sys.exit(1)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Updating prompt '{prompt_name}' with new content: \
+                \n\n=======\n{prompt_value}\n=======\n\n"
+            )
+        )
+
+        cache = get_django_cache()
+        client = LangsmithClient(api_key=os.environ.get("LANGSMITH_API_KEY"))
+        prompt_key = prompt_env_key(prompt_name)
+        try:
+            current_value = client.pull_prompt(prompt_key).messages[0].prompt.template
+            if current_value != prompt_value:
+                # Prompt exists with different content, make user confirm overwrite
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Prompt {prompt_key} already exists with different content:\
+                        \n\n=======\n{current_value}\n=======\n\n"
+                    )
+                )
+                confirmation = input(
+                    f"Do you want to overwrite '{prompt_key}'? (y/n): "
+                ).lower()
+                if confirmation in ["y", "yes"]:
+                    new_prompt_template = ChatPromptTemplate([("system", prompt_value)])
+                    client.push_prompt(prompt_key, object=new_prompt_template)
+                    cache.delete(prompt_name)
+                else:
+                    self.stdout.write(self.style.ERROR("Prompt update cancelled."))
+                    sys.exit(0)
+        except LangSmithNotFoundError:
+            # New prompt, push it to LangSmith
+            prompt = ChatPromptTemplate([("system", prompt_value)])
+            client.push_prompt(prompt_key, object=prompt)
+            cache.delete(prompt_name)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully updated prompt '{prompt_key}' on LangSmith."
+            )
+        )
+        return 0

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -1,7 +1,7 @@
 """Default prompts for various AI chatbots.  Tutor prompts are in a separate repo"""
 
-PROMPT_RECOMMENDATION = """"You are an assistant helping users find courses from a
-catalog of learning resources. Users can ask about specific topics, levels, or
+PROMPT_RECOMMENDATION = """"You are an assistant named Tim, helping users find courses
+from a catalog of learning resources. Users can ask about specific topics, levels, or
 recommendations based on their interests or goals.  Do not answer questions that are
 not related to educational resources at MIT.
 
@@ -54,8 +54,8 @@ AGAIN: NEVER USE ANY INFORMATION OUTSIDE OF THE MIT SEARCH RESULTS TO
 ANSWER QUESTIONS."""
 
 
-PROMPT_SYLLABUS = """You are an assistant helping users answer questions related
-to a syllabus.
+PROMPT_SYLLABUS = """You are an assistant named Tim, helping users answer questions
+related to a syllabus.
 
 Your job:
 1. Use the available function to gather relevant information about the user's question.
@@ -69,8 +69,8 @@ ANSWER QUESTIONS.  If no results are returned, say you could not find any releva
 information."""
 
 
-PROMPT_VIDEO_GPT = """You are an assistant helping users answer questions related
-to a video transcript.
+PROMPT_VIDEO_GPT = """You are an assistant named Tim, helping users answer questions
+related to a video transcript.
 Your job:
 1. Use the available function to gather relevant information about the user's question.
 2. Provide a clear, user-friendly summary of the information retrieved by the tool to


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7163

### Description (What does it do?)
- Adds "your name is Tim" to the recommendation, syllabus, and video bot system prompts.
- Adds a mgmt command to update system prompts in langsmith, with user confirmation required if the prompt already exists in langsmith with a different value.


### How can this be tested?
- If you haven't done so already, set up langsmith integration as described [here](https://github.com/mitodl/learn-ai/blob/58be8feb76c4bc7a4b4216291e7805b0456dd717/README.md#langsmith-integration).
- Run these management commands:
  ```
  ./manage.py update_prompt --prompt recommendation
  ./manage.py update_prompt --prompt syllabus
  ./manage.py update_prompt --prompt video_gpt
  ```
  If these prompts already exist in your langsmith account, you should be shown the current and proposed prompt value and you will need to confirm the change.  Otherwise you'll just be shown the prompt value to be assigned, and it should succeed.
- Go to the syllabus bot tab and ask it various questions like "Is your name Tim" (it should affirm that) and "Hi Tim, what's this course about?"  It should not get angry about you calling it by that name.  Repeat for the recommendation and video bots.   The tutor bot already doesn't seem to care about what you call it.

