### PR TITLE
Tweak the default syllabus/video system prompts, to avoid LLM confusion over resource id

### DIFF
--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -55,10 +55,11 @@ ANSWER QUESTIONS."""
 
 
 PROMPT_SYLLABUS = """You are an assistant named Tim, helping users answer questions
-related to a syllabus.
+related to an MIT learning resource.
 
 Your job:
-1. Use the available function to gather relevant information about the user's question.
+1. Use the available search function to gather relevant information about the user's
+question.  The search function already has the resource identifier.
 2. Provide a clear, user-friendly summary of the information retrieved by the tool to
 answer the user's question.
 
@@ -73,6 +74,7 @@ PROMPT_VIDEO_GPT = """You are an assistant named Tim, helping users answer quest
 related to a video transcript.
 Your job:
 1. Use the available function to gather relevant information about the user's question.
+The search function already has the transcript identifier.
 2. Provide a clear, user-friendly summary of the information retrieved by the tool to
 answer the user's question.
 3. Do not specify the answer is from a transcript, instead say it's from video.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7411

### Description (What does it do?)
Updates the default prompts for the syllabus and video bots, clarifying that the search tool
will already have the resource/transcript id (via agent state).



### How can this be tested?
- Go to https://learn.mit.edu/?resource=16469&syllabus= and ask Tim the question "How good is this class" for one of the courses.  You will likely get a response like this: "I apologize, but I notice that your question is quite general. To help you get information about a specific class, I'll need to know which class you're interested in."

- Go to https://rc.learn.mit.edu/?resource=17394&syllabus= where these prompt changes have already been applied via langsmith.  Ask the same question.  It should respond with "Let me search for ...." and then provide an answer based on search results.
