### PR TITLE
Enable the recommendation bot to search for specific resource details

### DIFF
--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import (
-    AIMessage,
     AnyMessage,
     RemoveMessage,
     SystemMessage,
@@ -144,7 +143,7 @@ def summarize_messages(  # noqa: PLR0912, PLR0913, PLR0915, C901
     else:
         existing_system_message = None
 
-    if not messages:
+    if not messages or isinstance(messages[-1], ToolMessage):
         return SummarizationResult(
             running_summary=running_summary,
             messages=(
@@ -211,15 +210,6 @@ def summarize_messages(  # noqa: PLR0912, PLR0913, PLR0915, C901
         messages_to_summarize = []
     else:
         messages_to_summarize = messages[total_summarized_messages : idx + 1]
-
-    # If the last message is an AI message with tool calls,
-    # wait until the next user message to summarize.
-    if (
-        messages_to_summarize
-        and isinstance(messages_to_summarize[-1], AIMessage)
-        and messages_to_summarize[-1].tool_calls
-    ):
-        messages_to_summarize = []
 
     if messages_to_summarize:
         if running_summary:

--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -60,7 +60,9 @@ def get_search_tool_metadata(thread_id: str, latest_state: TypedDict) -> str:
             }
             return json.dumps(metadata)
         except json.JSONDecodeError:
-            log.exception("Error parsing tool metadata, not valid JSON")
+            log.exception(
+                "Error parsing tool metadata, not valid JSON: %s", msg_content
+            )
             return json.dumps(
                 {"error": "Error parsing tool metadata", "content": msg_content}
             )

--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -143,6 +143,8 @@ def summarize_messages(  # noqa: PLR0912, PLR0913, PLR0915, C901
     else:
         existing_system_message = None
 
+    # if there are no messages to summarize, or the last message
+    # is a tool call, do not invoke the summarization model.
     if not messages or isinstance(messages[-1], ToolMessage):
         return SummarizationResult(
             running_summary=running_summary,
@@ -229,6 +231,7 @@ def summarize_messages(  # noqa: PLR0912, PLR0913, PLR0915, C901
             )
         log.debug("messages to summarize: %s", messages_to_summarize)
         summary_response = model.invoke(summary_messages.messages)
+        log.debug("Summarization response: %s", summary_response.content)
         summarized_message_ids = summarized_message_ids | {
             message.id for message in messages_to_summarize
         }

--- a/ai_chatbots/api_test.py
+++ b/ai_chatbots/api_test.py
@@ -111,9 +111,9 @@ def test_summarize_first_time():
         AIMessage(content="Response 2", id="4"),
         HumanMessage(content="Message 3", id="5"),
         AIMessage(content="Response 3", id="6"),
+        # these messages will be added to the result post-summarization
         HumanMessage(content="Message 4", id="7"),
         AIMessage(content="Response 4", id="8"),
-        # this message should be added to the result post-summarization
         HumanMessage(content="Latest message", id="9"),
     ]
 
@@ -132,21 +132,20 @@ def test_summarize_first_time():
     assert len(model.invoke_calls) == 1
 
     # Check that the result has the expected structure:
-    # - First message should be a summary of all but last human message
-    # - Last message should be the last human message
-    assert len(result.messages) == 2
+    # - First message should be a summary
+    # - Last 3 messages should be the last 3 original messages
+    assert len(result.messages) == 4
     assert result.messages[0].type == "system"
     assert "summary" in result.messages[0].content.lower()
-    assert result.messages[-1] == messages[-1]
+    assert result.messages[-3:] == messages[-3:]
 
     # Check the summary value
     summary_value = result.running_summary
     assert summary_value is not None
     assert summary_value.summary == "This is a summary of the conversation."
-    assert summary_value.summarized_message_ids == {msg.id for msg in messages[:-1]}
+    assert summary_value.summarized_message_ids == {msg.id for msg in messages[:-3]}
 
     # Test subsequent invocation (no new summary needed)
-    messages.append(factories.HumanMessageFactory.create())
     result = summarize_messages(
         messages,
         running_summary=summary_value,
@@ -155,13 +154,13 @@ def test_summarize_first_time():
         max_tokens=6,
         max_summary_tokens=max_summary_tokens,
     )
-    assert len(result.messages) == 3
+    assert len(result.messages) == 4
     assert result.messages[0].type == "system"
     assert (
         result.messages[0].content
         == "Summary of the conversation so far: This is a summary of the conversation."
     )
-    assert result.messages[-1:] == messages[-1:]
+    assert result.messages[-3:] == messages[-3:]
 
 
 def test_max_tokens_before_summary():
@@ -251,9 +250,9 @@ def test_with_system_message():
         AIMessage(content="Response 2", id="4"),
         HumanMessage(content="Message 3", id="5"),
         AIMessage(content="Response 3", id="6"),
+        # these messages will be added to the result post-summarization
         HumanMessage(content="Message 4", id="7"),
         AIMessage(content="Response 4", id="8"),
-        # this message will be added to the result post-summarization
         HumanMessage(content="Latest message", id="9"),
     ]
 
@@ -272,7 +271,7 @@ def test_with_system_message():
 
     # Check that model was called
     assert len(model.invoke_calls) == 1
-    assert model.invoke_calls[0] == messages[1:-1] + [
+    assert model.invoke_calls[0] == messages[1:7] + [
         HumanMessage(content="Create a summary of the conversation above:")
     ]
 
@@ -280,11 +279,11 @@ def test_with_system_message():
     # - System message should be preserved
     # - Second message should be a summary of messages 2-5
     # - Last 3 messages should be the last 3 original messages
-    assert len(result.messages) == 3
+    assert len(result.messages) == 5
     assert result.messages[0].type == "system"
     assert result.messages[1].type == "system"  # Summary message
     assert "summary" in result.messages[1].content.lower()
-    assert result.messages[-1] == messages[-1]
+    assert result.messages[2:] == messages[-3:]
 
 
 def test_approximate_token_counter():
@@ -621,14 +620,15 @@ def test_missing_message_ids():
     messages = [
         HumanMessage(content="Message 1", id="1"),
         AIMessage(content="Response"),  # Missing ID
+        HumanMessage(content="Message 2", id="1"),
     ]
     with pytest.raises(ValueError, match="Messages are required to have ID field"):
         summarize_messages(
             messages,
             running_summary=None,
             model=MockChatModel(responses=[]),
-            max_tokens=10,
-            max_summary_tokens=10,
+            max_tokens=1,
+            max_summary_tokens=1,
         )
 
 

--- a/ai_chatbots/api_test.py
+++ b/ai_chatbots/api_test.py
@@ -598,21 +598,21 @@ def test_last_ai_with_tool_calls(is_tool_call):
         running_summary=None,
         model=model,
         token_counter=len,
-        max_tokens_before_summary=6,
-        max_tokens=6,
-        max_summary_tokens=3,
+        max_tokens_before_summary=2,
+        max_tokens=2,
+        max_summary_tokens=1,
     )
 
     # Check that the AI message with tool calls was summarized together with the tool messages
-    assert len(result.messages) == (7 if is_tool_call else 1)
+    assert len(result.messages) == (7 if is_tool_call else 2)
     assert result.messages[0].type == ("human" if is_tool_call else "system")
-    assert result.messages[-1].type == ("tool" if is_tool_call else "system")
+    assert result.messages[-1].type == ("tool" if is_tool_call else "human")
 
     if is_tool_call:
         assert result.running_summary is None
     else:
         assert result.running_summary.summarized_message_ids == {
-            msg.id for msg in messages
+            msg.id for msg in messages[:-1]
         }
 
 
@@ -653,8 +653,10 @@ def test_duplicate_message_ids():
 
     # Second summarization with a duplicate ID
     messages2 = [
+        AIMessage(content="Response 1", id="2"),  # Duplicate ID
+        HumanMessage(content="Message 2", id="3"),  # Duplicate ID
         AIMessage(content="Response 2", id="4"),
-        HumanMessage(content="Message 3", id="1"),  # Duplicate ID
+        HumanMessage(content="Message 3", id="5"),
     ]
 
     with pytest.raises(ValueError, match="has already been summarized"):
@@ -663,7 +665,7 @@ def test_duplicate_message_ids():
             running_summary=result.running_summary,
             model=model,
             token_counter=len,
-            max_tokens=5,
+            max_tokens=6,
             max_summary_tokens=1,
         )
 

--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -41,7 +41,6 @@ from ai_chatbots import tools
 from ai_chatbots.api import CustomSummarizationNode, get_search_tool_metadata
 from ai_chatbots.models import TutorBotOutput
 from ai_chatbots.prompts import PROMPT_MAPPING
-from ai_chatbots.tools import get_video_transcript_chunk, search_content_files
 from ai_chatbots.utils import get_django_cache
 
 log = logging.getLogger(__name__)
@@ -405,7 +404,7 @@ class ResourceRecommendationBot(SummarizingChatbot):
 
     def create_tools(self) -> list[BaseTool]:
         """Create tools required by the agent"""
-        return [tools.search_courses]
+        return [tools.search_courses, tools.search_content_files]
 
     async def get_tool_metadata(self) -> str:
         """Return the metadata for the search tool"""
@@ -457,7 +456,7 @@ class SyllabusBot(SummarizingChatbot):
 
     def create_tools(self):
         """Create tools required by the agent"""
-        return [search_content_files]
+        return [tools.search_content_files]
 
     async def get_tool_metadata(self) -> str:
         """Return the metadata for the search tool"""
@@ -687,7 +686,7 @@ class VideoGPTBot(SummarizingChatbot):
 
     def create_tools(self):
         """Create tools required for the agent"""
-        return [get_video_transcript_chunk]
+        return [tools.get_video_transcript_chunk]
 
     async def get_tool_metadata(self) -> str:
         """Return the metadata for the search tool"""

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -147,6 +147,7 @@ async def test_recommendation_bot_tool(settings, mocker, search_results):
     retained_attributes = [
         "title",
         "id",
+        "readable_id",
         "description",
         "offered_by",
         "free",

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -83,9 +83,11 @@ information."""
 
 # The following prompts are similar or identical to the default ones in
 # langmem.short_term.summarization
-PROMPT_SUMMARY_INITIAL = """Create a summary of the conversation above.
-If there are any tool results, include the full output of the latest one in
-the summary.
+PROMPT_SUMMARY_INITIAL = """Create a summary of the conversation above, incorporating
+thevprevious summary if any.
+If there are any tool results, include the full output of the latest tool message in
+the summary.  You must also retain all title and readable_id field values from all tool
+messages and any previous summaries in this new summary.
 """
 PROMPT_SUMMARY_EXISTING = """This is summary of the conversation so far:
 {existing_summary}

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -7,17 +7,15 @@ not related to educational resources at MIT.
 
 Your job:
 1. Understand the user's intent AND BACKGROUND based on their message.
-2. Use the available function to gather information or recommend courses.
+2. Use the available tools to gather information or recommend courses.
 3. Provide a clear, user-friendly explanation of your recommendations if search results
 are found.
 
 
-Run the tool to find learning resources that the user is interested in,
-and answer only based on the function search
-results.
-
-VERY IMPORTANT: NEVER USE ANY INFORMATION OUTSIDE OF THE MIT SEARCH RESULTS TO
-ANSWER QUESTIONS.
+Run the "search_courses" tool to find learning resources that the user is interested in,
+and answer only based on the function search results.   If the user asks for more
+specific information about a particular resource, use the "search_content_files" tool
+to find an answer, using the course_id from the search results as the course_id.
 
 If no results are returned, say you could not find any relevant
 resources.  Don't say you're going to try again.  Ask the user if they would like to
@@ -48,10 +46,7 @@ prepare me for the AI future.”
 Expected Output: Maybe ask whether the user wants to learn how to program, or just use
 AI in their discipline - does this person want to study machine learning? More info
 needed. Then perform a relevant search and send back the best results.
-
-
-AGAIN: NEVER USE ANY INFORMATION OUTSIDE OF THE MIT SEARCH RESULTS TO
-ANSWER QUESTIONS."""
+"""
 
 
 PROMPT_SYLLABUS = """You are an assistant named Tim, helping users answer questions
@@ -64,7 +59,8 @@ question.  The search function already has the resource identifier.
 answer the user's question.
 
 Always use the tool results to answer questions, and answer only based on the tool
-output. Do not include the course id in the query parameter.
+output. Do not include the course_id in the query parameter.  The tool always has
+access to the course id.
 VERY IMPORTANT: NEVER USE ANY INFORMATION OUTSIDE OF THE TOOL OUTPUT TO
 ANSWER QUESTIONS.  If no results are returned, say you could not find any relevant
 information."""

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -15,7 +15,7 @@ are found.
 Run the "search_courses" tool to find learning resources that the user is interested in,
 and answer only based on the function search results.   If the user asks for more
 specific information about a particular resource, use the "search_content_files" tool
-to find an answer, using the course_id from the search results as the course_id.
+to find an answer.
 
 If no results are returned, say you could not find any relevant
 resources.  Don't say you're going to try again.  Ask the user if they would like to

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -186,20 +186,22 @@ def search_courses(
 
 
 class SearchContentFilesToolSchema(pydantic.BaseModel):
-    """Schema for searching MIT contentfiles related to a particular course."""
+    """
+    Schema for searching MIT contentfiles related to a particular learning resource.
+    """
 
     q: str = Field(
-        description=(
-            "Query to find course information that might answer the user's question."
-        )
+        description=("Query to find requested information about a learning resource.")
     )
 
-    course_id: Optional[str] = Field(
-        description=("The course_id to use if not provided in the agent state. "),
+    readable_id: Optional[str] = Field(
+        description=("The readable_id of the learning resource."),
     )
 
     state: Annotated[dict, InjectedState] = Field(
-        description="The agent state, including course_id and collection_name params"
+        description=(
+            "Agent state, which may include course_id (readable_id) and collection_name"
+        )
     )
 
 
@@ -219,15 +221,16 @@ class VideoGPTToolSchema(pydantic.BaseModel):
 
 @tool(args_schema=SearchContentFilesToolSchema)
 def search_content_files(
-    q: str, state: Annotated[dict, InjectedState], course_id: str | None = None
+    q: str, state: Annotated[dict, InjectedState], readable_id: str | None = None
 ) -> str:
     """
-    Query the MIT contentfile vector endpoint API, and return results as a
-    JSON string, along with metadata about the query parameters used.
+    Search for detailed information about a particular MIT learning resource.
+    The resource is identified by its readable_id or course_id.
     """
 
     url = settings.AI_MIT_SYLLABUS_URL
-    course_id = state.get("course_id", [None])[-1] or course_id
+    # Use the state course_id if available, otherwise use the provided course_id
+    course_id = state.get("course_id", [None])[-1] or readable_id
     collection_name = state.get("collection_name", [None])[-1]
     params = {
         "q": q,

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -160,7 +160,6 @@ def search_courses(
             simplified_result["url"] = (
                 f"{settings.AI_MIT_SEARCH_DETAIL_URL}{result.pop('id')}"
             )
-            simplified_result["course_id"] = result.pop("readable_id", None)
             # Instructors and level will be in the runs data if present
             next_date = result.get("next_start_date", None)
             raw_runs = result.get("runs", [])
@@ -196,6 +195,7 @@ class SearchContentFilesToolSchema(pydantic.BaseModel):
 
     readable_id: Optional[str] = Field(
         description=("The readable_id of the learning resource."),
+        default=None,
     )
 
     state: Annotated[dict, InjectedState] = Field(

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -195,10 +195,7 @@ class SearchContentFilesToolSchema(pydantic.BaseModel):
     )
 
     course_id: Optional[str] = Field(
-        description=(
-            "The course ID to search for content files related to the course."
-            "Do not include the course ID in the q parameter."
-        )
+        description=("The course_id to use if not provided in the agent state. "),
     )
 
     state: Annotated[dict, InjectedState] = Field(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6542

### Description (What does it do?)
- Adds the `search_content_files` tool to the list of tools available to the recommendation bot, and tweaks the system prompt to provide guidance on when to use it.
- Adjusts the summarization node/function to work more appropriately (noticed some issues during testing, since the trigger to use it was hit more often due to the greater # of tokens used up by the content files tool).


### How can this be tested?
Ask for course recommendations, then ask for some detailed info about 1 or more of the courses (how is it graded, are there any class projects, etc).  Keep the conversation going for awhile to ensure the summarization is hit, responses seem reasonable, and no exceptions occur.

### Additional Context
I needed to make some changes to the summarization code, because it assumed one tool call at a time, and after a couple rounds of summarization led to some tool output messages getting truncated from the list of messages sent to the summarization llm, leading to exceptions.  As part of fixing that, I also simplified it a bit and forced it to create a summary only if the final message is a human message, to fully prevent any occurrences of `human input -> tool call -> summarization -> response` which often led to subpar responses compared to `human input -> summarization -> tool call -> response`.