### PR TITLE
More summary prompt tweaking

### DIFF
--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -84,14 +84,18 @@ information."""
 # The following prompts are similar or identical to the default ones in
 # langmem.short_term.summarization
 PROMPT_SUMMARY_INITIAL = """Create a summary of the conversation above, incorporating
-thevprevious summary if any.
+the previous summary if any.
 If there are any tool results, include the full output of the latest tool message in
-the summary.  You must also retain all title and readable_id field values from all tool
-messages and any previous summaries in this new summary.
+the summary.  You must also retain all "title" and "readable_id" field values from all
+tool messages and any previous summaries in this new summary.
 """
 PROMPT_SUMMARY_EXISTING = """This is summary of the conversation so far:
 {existing_summary}
-\n\nExtend this summary by taking into account the new messages above:"""
+\n\nExtend this summary by taking into account the new messages above.
+If there are any tool results, include the full output of the latest tool message in
+the summary.  You must also retain all "title" and "readable_id" field values from all
+tool messages and any previous summaries in this new summary.
+"""
 PROMPT_SUMMARY_FINAL = """Summary of the conversation so far: {summary}"""
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/learn-ai/pull/205

### Description (What does it do?)
Tweaks the summarization prompts to remove a type and instruct the LLM to retain readable_ids and titles (in quotes) for existing summaries as well as initial summaries.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
WIth the recommendation bot, and with langsmith disabled, ask a bunch of questions about "both courses" after receiving an initial response for your topic of interest:
- what are the prerequisites for each course
- how is each course graded
- who teaches each course
- are there any class projects for either course
- it should not seem to lose track of which course has which readable_id

