### PR TITLE
Revert overwrite of search_content_files change

### DIFF
--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -274,7 +274,7 @@ def search_content_files(
 
     url = settings.AI_MIT_SYLLABUS_URL
     course_id = state.get("course_id", [None])[-1] or readable_id
-    collection_name = state["collection_name"][-1]
+    collection_name = state.get("collection_name", [None])[-1]
     params = {
         "q": q,
         "resource_readable_id": course_id,
@@ -295,7 +295,7 @@ def search_related_course_content_files(
     JSON string, along with metadata about the query parameters used.
     """
     url = settings.AI_MIT_SYLLABUS_URL
-    collection_name = state["collection_name"][-1]
+    collection_name = state.get("collection_name", [None])[-1]
     related_courses = state["related_courses"]
     params = {
         "q": q,

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -109,6 +109,7 @@ def test_request_exception(mocker):
     ("search_url", "limit"),
     [("https://mit.edu/search", 5), ("https://mit.edu/vector", 10)],
 )
+@pytest.mark.parametrize("no_collection_name", [True, False])
 def test_search_content_files(  # noqa: PLR0913
     settings,
     mock_get_resources,
@@ -116,6 +117,7 @@ def test_search_content_files(  # noqa: PLR0913
     search_results,
     search_url,
     limit,
+    no_collection_name,
 ):
     """Test that the search_courses tool returns expected results w/expected params."""
     settings.AI_MIT_SYLLABUS_URL = search_url
@@ -127,6 +129,10 @@ def test_search_content_files(  # noqa: PLR0913
         "resource_readable_id": syllabus_agent_state["course_id"][-1],
         "collection_name": syllabus_agent_state["collection_name"][-1],
     }
+    if no_collection_name:
+        expected_params.pop("collection_name")
+        syllabus_agent_state.pop("collection_name")
+
     results = json.loads(
         search_content_files.invoke({"q": "main topics", "state": syllabus_agent_state})
     )


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/learn-ai/pull/205

### Description (What does it do?)
Reverts an overwrite of this recent change (maybe from a rebase?): https://github.com/mitodl/learn-ai/blob/60332909ee3441cbc35e16741d93e54c7f6ee04a/ai_chatbots/tools.py#L234

Adds unit test to check for above.

### How can this be tested?
Recommendation bot should work when you ask details about a course it returns from a previous query.

