### PR TITLE
AI system prompts endpoint

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -39,7 +39,7 @@ from typing_extensions import TypedDict
 from ai_chatbots import tools
 from ai_chatbots.api import CustomSummarizationNode, get_search_tool_metadata
 from ai_chatbots.models import TutorBotOutput
-from ai_chatbots.prompts import PROMPT_MAPPING
+from ai_chatbots.prompts import SYSTEM_PROMPT_MAPPING
 from ai_chatbots.utils import get_django_cache, request_with_token
 
 log = logging.getLogger(__name__)
@@ -74,7 +74,9 @@ class BaseChatbot(ABC):
         self.temperature = temperature or settings.AI_DEFAULT_TEMPERATURE
         self.instructions = (
             instructions
-            or get_system_prompt(self.PROMPT_TEMPLATE, PROMPT_MAPPING, get_django_cache)
+            or get_system_prompt(
+                self.PROMPT_TEMPLATE, SYSTEM_PROMPT_MAPPING, get_django_cache
+            )
             if self.PROMPT_TEMPLATE
             else None
         )
@@ -288,7 +290,9 @@ class SummarizingChatbot(BaseChatbot):
             ("placeholder", "{messages}"),
             (
                 "user",
-                get_system_prompt("summary_initial", PROMPT_MAPPING, get_django_cache),
+                get_system_prompt(
+                    "summary_initial", SYSTEM_PROMPT_MAPPING, get_django_cache
+                ),
             ),
         ]
     )
@@ -298,7 +302,9 @@ class SummarizingChatbot(BaseChatbot):
             ("placeholder", "{messages}"),
             (
                 "user",
-                get_system_prompt("summary_existing", PROMPT_MAPPING, get_django_cache),
+                get_system_prompt(
+                    "summary_existing", SYSTEM_PROMPT_MAPPING, get_django_cache
+                ),
             ),
         ]
     )
@@ -309,7 +315,9 @@ class SummarizingChatbot(BaseChatbot):
             ("placeholder", "{system_message}"),
             (
                 "system",
-                get_system_prompt("summary_final", PROMPT_MAPPING, get_django_cache),
+                get_system_prompt(
+                    "summary_final", SYSTEM_PROMPT_MAPPING, get_django_cache
+                ),
             ),
             ("placeholder", "{messages}"),
         ]

--- a/ai_chatbots/management/commands/clear_prompt_cache.py
+++ b/ai_chatbots/management/commands/clear_prompt_cache.py
@@ -7,7 +7,7 @@ from open_learning_ai_tutor.prompts import (
     prompt_env_key,
 )
 
-from ai_chatbots.prompts import PROMPT_MAPPING
+from ai_chatbots.prompts import SYSTEM_PROMPT_MAPPING
 from ai_chatbots.utils import get_django_cache
 
 all_prompt_keys = [
@@ -15,7 +15,7 @@ all_prompt_keys = [
     for key in (
         list(intent_prompt_mapping.keys())
         + list(assessment_prompt_mapping.keys())
-        + list(PROMPT_MAPPING.keys())
+        + list(SYSTEM_PROMPT_MAPPING.keys())
         + ["tutor_initial_assessment", "tutor_problem"]
     )
 ]

--- a/ai_chatbots/management/commands/update_prompt.py
+++ b/ai_chatbots/management/commands/update_prompt.py
@@ -15,7 +15,7 @@ from open_learning_ai_tutor.prompts import (
     prompt_env_key,
 )
 
-from ai_chatbots.prompts import PROMPT_MAPPING
+from ai_chatbots.prompts import SYSTEM_PROMPT_MAPPING
 from ai_chatbots.utils import get_django_cache
 
 
@@ -58,7 +58,7 @@ class Command(BaseCommand):
 
         if not prompt_value and not prompt_file_value:
             for mapping in (
-                PROMPT_MAPPING,
+                SYSTEM_PROMPT_MAPPING,
                 TUTOR_PROMPT_MAPPING,
                 assessment_prompt_mapping,
                 intent_prompt_mapping,

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -99,10 +99,15 @@ tool messages and any previous summaries in this new summary.
 PROMPT_SUMMARY_FINAL = """Summary of the conversation so far: {summary}"""
 
 
-PROMPT_MAPPING = {
+CHATBOT_PROMPT_MAPPING = {
     "recommendation": PROMPT_RECOMMENDATION,
     "syllabus": PROMPT_SYLLABUS,
     "video_gpt": PROMPT_VIDEO_GPT,
+}
+
+
+SYSTEM_PROMPT_MAPPING = {
+    **CHATBOT_PROMPT_MAPPING,
     "summary_initial": PROMPT_SUMMARY_INITIAL,
     "summary_existing": PROMPT_SUMMARY_EXISTING,
     "summary_final": PROMPT_SUMMARY_FINAL,

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -1,6 +1,6 @@
 """Default prompts for various AI chatbots.  Tutor prompts are in a separate repo"""
 
-PROMPT_RECOMMENDATION = """"You are an assistant named Tim, helping users find courses
+PROMPT_RECOMMENDATION = """You are an assistant named Tim, helping users find courses
 from a catalog of learning resources. Users can ask about specific topics, levels, or
 recommendations based on their interests or goals.  Do not answer questions that are
 not related to educational resources at MIT.

--- a/ai_chatbots/prompts_test.py
+++ b/ai_chatbots/prompts_test.py
@@ -24,7 +24,8 @@ def test_langsmith_prompt_create(mocker):
         "open_learning_ai_tutor.prompts.LangsmithClient.push_prompt"
     )
     prompt = langsmith_prompt_template(
-        chatbots.ResourceRecommendationBot.PROMPT_TEMPLATE, prompts.PROMPT_MAPPING
+        chatbots.ResourceRecommendationBot.PROMPT_TEMPLATE,
+        prompts.SYSTEM_PROMPT_MAPPING,
     )
     assert prompt.messages[0].prompt.template == prompts.PROMPT_RECOMMENDATION
     mock_pull.assert_called_once_with("recommendation_dev")
@@ -75,7 +76,9 @@ def test_get_system_prompt_no_cache(mocker, has_cache):
         return_value=ChatPromptTemplate([("system", prompts.PROMPT_SYLLABUS)]),
     )
     prompt = get_system_prompt(
-        chatbots.SyllabusBot.PROMPT_TEMPLATE, prompts.PROMPT_MAPPING, get_test_cache
+        chatbots.SyllabusBot.PROMPT_TEMPLATE,
+        prompts.SYSTEM_PROMPT_MAPPING,
+        get_test_cache,
     )
     assert mock_pull.call_count == (0 if has_cache else 1)
     assert prompt == prompts.PROMPT_SYLLABUS
@@ -91,7 +94,9 @@ def test_get_system_prompt_no_langsmith(mocker):
         "open_learning_ai_tutor.prompts.LangsmithClient.pull_prompt"
     )
     prompt = get_system_prompt(
-        chatbots.SyllabusBot.PROMPT_TEMPLATE, prompts.PROMPT_MAPPING, get_django_cache
+        chatbots.SyllabusBot.PROMPT_TEMPLATE,
+        prompts.SYSTEM_PROMPT_MAPPING,
+        get_django_cache,
     )
     assert prompt == prompts.PROMPT_SYLLABUS
     mock_pull.assert_not_called()

--- a/ai_chatbots/serializers.py
+++ b/ai_chatbots/serializers.py
@@ -6,6 +6,13 @@ from rest_framework import serializers
 from ai_chatbots.models import DjangoCheckpoint, LLMModel, UserChatSession
 
 
+class SystemPromptSerializer(serializers.Serializer):
+    """Serializer for system prompts"""
+
+    prompt_name = serializers.CharField()
+    prompt_value = serializers.CharField()
+
+
 class ChatRequestSerializer(serializers.Serializer):
     """Serializer for chatbot requests"""
 

--- a/ai_chatbots/serializers.py
+++ b/ai_chatbots/serializers.py
@@ -32,7 +32,7 @@ class ChatRequestSerializer(serializers.Serializer):
     def validate_instructions(self, value):
         """Ensure that the user has permission"""
         user = self.context.get("user")
-        if not user or (not user.is_staff and not user.is_superuser):
+        if value and (not user or (not user.is_staff and not user.is_superuser)):
             err_msg = "You do not have permission to adjust the instructions."
             raise serializers.ValidationError(err_msg)
         return value

--- a/ai_chatbots/urls.py
+++ b/ai_chatbots/urls.py
@@ -17,7 +17,7 @@ router.register(
     basename="chat_session_messages",
 )
 router.register(r"llm_models", views.LLMModelViewSet, basename="llm_models")
-router.register(r"prompts", views.AgentPromptViewSet, basename="prompts")
+router.register(r"prompts", views.SystemPromptViewSet, basename="prompts")
 
 app_name = "ai"
 v0_urls = [

--- a/ai_chatbots/urls.py
+++ b/ai_chatbots/urls.py
@@ -17,6 +17,7 @@ router.register(
     basename="chat_session_messages",
 )
 router.register(r"llm_models", views.LLMModelViewSet, basename="llm_models")
+router.register(r"prompts", views.AgentPromptViewSet, basename="prompts")
 
 app_name = "ai"
 v0_urls = [

--- a/ai_chatbots/views.py
+++ b/ai_chatbots/views.py
@@ -222,7 +222,7 @@ def get_transcript_block_id(contentfile):
     return f"{transcript_id_prefix}@{english_transcript_id}"
 
 
-class AgentPromptViewSet(GenericViewSet):
+class SystemPromptViewSet(GenericViewSet):
     """
     API endpoint to retrieve chatbot system prompts.
     """

--- a/ai_chatbots/views.py
+++ b/ai_chatbots/views.py
@@ -222,6 +222,16 @@ def get_transcript_block_id(contentfile):
     return f"{transcript_id_prefix}@{english_transcript_id}"
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name="prompt_name",
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.PATH,
+            description="name of the system prompt",
+        )
+    ]
+)
 class SystemPromptViewSet(GenericViewSet):
     """
     API endpoint to retrieve chatbot system prompts.

--- a/ai_chatbots/views.py
+++ b/ai_chatbots/views.py
@@ -222,16 +222,6 @@ def get_transcript_block_id(contentfile):
     return f"{transcript_id_prefix}@{english_transcript_id}"
 
 
-@extend_schema(
-    parameters=[
-        OpenApiParameter(
-            name="prompt_name",
-            type=OpenApiTypes.STR,
-            location=OpenApiParameter.PATH,
-            description="name of the system prompt",
-        )
-    ]
-)
 class SystemPromptViewSet(GenericViewSet):
     """
     API endpoint to retrieve chatbot system prompts.
@@ -272,6 +262,16 @@ class SystemPromptViewSet(GenericViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="prompt_name",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="name of the system prompt",
+            )
+        ]
+    )
     def retrieve(self, request, *args, **kwargs):  # noqa: ARG002
         """Return a specific system prompt."""
         instance = self.get_object()

--- a/ai_chatbots/views.py
+++ b/ai_chatbots/views.py
@@ -7,19 +7,24 @@ from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from open_learning_ai_tutor.prompts import get_system_prompt
 from rest_framework import mixins, viewsets
+from rest_framework.exceptions import NotFound
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView as ApiView
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 
 from ai_chatbots.models import DjangoCheckpoint, LLMModel, UserChatSession
 from ai_chatbots.permissions import IsThreadOwner
+from ai_chatbots.prompts import CHATBOT_PROMPT_MAPPING
 from ai_chatbots.serializers import (
     ChatMessageSerializer,
     LLMModelSerializer,
+    SystemPromptSerializer,
     UserChatSessionSerializer,
 )
+from ai_chatbots.utils import get_django_cache
 from main.constants import VALID_HTTP_METHODS
 from main.views import DefaultPagination
 
@@ -215,3 +220,50 @@ def get_transcript_block_id(contentfile):
     transcript_id_prefix = "@".join(parts[:2])
 
     return f"{transcript_id_prefix}@{english_transcript_id}"
+
+
+class AgentPromptViewSet(GenericViewSet):
+    """
+    API endpoint to retrieve chatbot system prompts.
+    """
+
+    serializer_class = SystemPromptSerializer
+    permission_classes = (AllowAny,)
+    lookup_field = "prompt_name"
+
+    def get_queryset(self):
+        """Return all available chatbot prompts."""
+        return [
+            {
+                "prompt_name": name,
+                "prompt_value": get_system_prompt(
+                    name, CHATBOT_PROMPT_MAPPING, get_django_cache
+                ),
+            }
+            for name in CHATBOT_PROMPT_MAPPING
+        ]
+
+    def get_object(self):
+        """Return a specific system prompt."""
+        prompt_name = self.kwargs.get(self.lookup_field)
+        if prompt_name not in CHATBOT_PROMPT_MAPPING:
+            raise NotFound
+
+        return {
+            "prompt_name": prompt_name,
+            "prompt_value": get_system_prompt(
+                prompt_name, CHATBOT_PROMPT_MAPPING, get_django_cache
+            ),
+        }
+
+    def list(self, request, *args, **kwargs):  # noqa: ARG002
+        """Return a list of system prompts."""
+        queryset = self.get_queryset()
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):  # noqa: ARG002
+        """Return a specific system prompt."""
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/env/backend.env
+++ b/env/backend.env
@@ -10,7 +10,7 @@ CSRF_COOKIE_DOMAIN=open.odl.local
 CSRF_COOKIE_SECURE=False
 MITOL_COOKIE_DOMAIN=open.odl.local
 MITOL_COOKIE_NAME=learnai
-MITOL_APP_BASE_URL=http://ai.open.odl.local:8002
+MITOL_APP_BASE_URL=http://ai.open.odl.local:8005
 
 DEBUG=True
 DJANGO_LOG_LEVEL=INFO

--- a/frontend-demo/api/src/generated/v0/api.ts
+++ b/frontend-demo/api/src/generated/v0/api.ts
@@ -1986,13 +1986,20 @@ export const PromptsApiAxiosParamCreator = function (
   return {
     /**
      * Return a list of system prompts.
+     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     promptsList: async (
+      prompt_name: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v0/prompts/`
+      // verify required parameter 'prompt_name' is not null or undefined
+      assertParamExists("promptsList", "prompt_name", prompt_name)
+      const localVarPath = `/api/v0/prompts/`.replace(
+        `{${"prompt_name"}}`,
+        encodeURIComponent(String(prompt_name)),
+      )
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
       let baseOptions
@@ -2024,7 +2031,7 @@ export const PromptsApiAxiosParamCreator = function (
     },
     /**
      * Return a specific system prompt.
-     * @param {string} prompt_name
+     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2079,10 +2086,12 @@ export const PromptsApiFp = function (configuration?: Configuration) {
   return {
     /**
      * Return a list of system prompts.
+     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async promptsList(
+      prompt_name: string,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -2090,8 +2099,10 @@ export const PromptsApiFp = function (configuration?: Configuration) {
         basePath?: string,
       ) => AxiosPromise<Array<SystemPrompt>>
     > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.promptsList(options)
+      const localVarAxiosArgs = await localVarAxiosParamCreator.promptsList(
+        prompt_name,
+        options,
+      )
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
         operationServerMap["PromptsApi.promptsList"]?.[index]?.url
@@ -2105,7 +2116,7 @@ export const PromptsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Return a specific system prompt.
-     * @param {string} prompt_name
+     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2146,14 +2157,16 @@ export const PromptsApiFactory = function (
   return {
     /**
      * Return a list of system prompts.
+     * @param {PromptsApiPromptsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     promptsList(
+      requestParameters: PromptsApiPromptsListRequest,
       options?: RawAxiosRequestConfig,
     ): AxiosPromise<Array<SystemPrompt>> {
       return localVarFp
-        .promptsList(options)
+        .promptsList(requestParameters.prompt_name, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -2174,13 +2187,27 @@ export const PromptsApiFactory = function (
 }
 
 /**
+ * Request parameters for promptsList operation in PromptsApi.
+ * @export
+ * @interface PromptsApiPromptsListRequest
+ */
+export interface PromptsApiPromptsListRequest {
+  /**
+   * name of the system prompt
+   * @type {string}
+   * @memberof PromptsApiPromptsList
+   */
+  readonly prompt_name: string
+}
+
+/**
  * Request parameters for promptsRetrieve operation in PromptsApi.
  * @export
  * @interface PromptsApiPromptsRetrieveRequest
  */
 export interface PromptsApiPromptsRetrieveRequest {
   /**
-   *
+   * name of the system prompt
    * @type {string}
    * @memberof PromptsApiPromptsRetrieve
    */
@@ -2196,13 +2223,17 @@ export interface PromptsApiPromptsRetrieveRequest {
 export class PromptsApi extends BaseAPI {
   /**
    * Return a list of system prompts.
+   * @param {PromptsApiPromptsListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PromptsApi
    */
-  public promptsList(options?: RawAxiosRequestConfig) {
+  public promptsList(
+    requestParameters: PromptsApiPromptsListRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
     return PromptsApiFp(this.configuration)
-      .promptsList(options)
+      .promptsList(requestParameters.prompt_name, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/frontend-demo/api/src/generated/v0/api.ts
+++ b/frontend-demo/api/src/generated/v0/api.ts
@@ -263,6 +263,25 @@ export interface SyllabusAgentV0Request {
   thread_id?: string
 }
 /**
+ * Serializer for system prompts
+ * @export
+ * @interface SystemPrompt
+ */
+export interface SystemPrompt {
+  /**
+   *
+   * @type {string}
+   * @memberof SystemPrompt
+   */
+  prompt_name: string
+  /**
+   *
+   * @type {string}
+   * @memberof SystemPrompt
+   */
+  prompt_value: string
+}
+/**
  * Serializer for user chat sessions
  * @export
  * @interface UserChatSession
@@ -1953,6 +1972,253 @@ export class LlmModelsApi extends BaseAPI {
   ) {
     return LlmModelsApiFp(this.configuration)
       .llmModelsRetrieve(requestParameters.litellm_id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * PromptsApi - axios parameter creator
+ * @export
+ */
+export const PromptsApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * Return a list of system prompts.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    promptsList: async (
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/api/v0/prompts/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Return a specific system prompt.
+     * @param {string} prompt_name
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    promptsRetrieve: async (
+      prompt_name: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'prompt_name' is not null or undefined
+      assertParamExists("promptsRetrieve", "prompt_name", prompt_name)
+      const localVarPath = `/api/v0/prompts/{prompt_name}/`.replace(
+        `{${"prompt_name"}}`,
+        encodeURIComponent(String(prompt_name)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * PromptsApi - functional programming interface
+ * @export
+ */
+export const PromptsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = PromptsApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * Return a list of system prompts.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async promptsList(
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<Array<SystemPrompt>>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.promptsList(options)
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["PromptsApi.promptsList"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * Return a specific system prompt.
+     * @param {string} prompt_name
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async promptsRetrieve(
+      prompt_name: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<SystemPrompt>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.promptsRetrieve(
+        prompt_name,
+        options,
+      )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["PromptsApi.promptsRetrieve"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * PromptsApi - factory interface
+ * @export
+ */
+export const PromptsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = PromptsApiFp(configuration)
+  return {
+    /**
+     * Return a list of system prompts.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    promptsList(
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<Array<SystemPrompt>> {
+      return localVarFp
+        .promptsList(options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Return a specific system prompt.
+     * @param {PromptsApiPromptsRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    promptsRetrieve(
+      requestParameters: PromptsApiPromptsRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<SystemPrompt> {
+      return localVarFp
+        .promptsRetrieve(requestParameters.prompt_name, options)
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for promptsRetrieve operation in PromptsApi.
+ * @export
+ * @interface PromptsApiPromptsRetrieveRequest
+ */
+export interface PromptsApiPromptsRetrieveRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof PromptsApiPromptsRetrieve
+   */
+  readonly prompt_name: string
+}
+
+/**
+ * PromptsApi - object-oriented interface
+ * @export
+ * @class PromptsApi
+ * @extends {BaseAPI}
+ */
+export class PromptsApi extends BaseAPI {
+  /**
+   * Return a list of system prompts.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof PromptsApi
+   */
+  public promptsList(options?: RawAxiosRequestConfig) {
+    return PromptsApiFp(this.configuration)
+      .promptsList(options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Return a specific system prompt.
+   * @param {PromptsApiPromptsRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof PromptsApi
+   */
+  public promptsRetrieve(
+    requestParameters: PromptsApiPromptsRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return PromptsApiFp(this.configuration)
+      .promptsRetrieve(requestParameters.prompt_name, options)
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/frontend-demo/api/src/generated/v0/api.ts
+++ b/frontend-demo/api/src/generated/v0/api.ts
@@ -1986,20 +1986,13 @@ export const PromptsApiAxiosParamCreator = function (
   return {
     /**
      * Return a list of system prompts.
-     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     promptsList: async (
-      prompt_name: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'prompt_name' is not null or undefined
-      assertParamExists("promptsList", "prompt_name", prompt_name)
-      const localVarPath = `/api/v0/prompts/`.replace(
-        `{${"prompt_name"}}`,
-        encodeURIComponent(String(prompt_name)),
-      )
+      const localVarPath = `/api/v0/prompts/`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
       let baseOptions
@@ -2086,12 +2079,10 @@ export const PromptsApiFp = function (configuration?: Configuration) {
   return {
     /**
      * Return a list of system prompts.
-     * @param {string} prompt_name name of the system prompt
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async promptsList(
-      prompt_name: string,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -2099,10 +2090,8 @@ export const PromptsApiFp = function (configuration?: Configuration) {
         basePath?: string,
       ) => AxiosPromise<Array<SystemPrompt>>
     > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.promptsList(
-        prompt_name,
-        options,
-      )
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.promptsList(options)
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
         operationServerMap["PromptsApi.promptsList"]?.[index]?.url
@@ -2157,16 +2146,14 @@ export const PromptsApiFactory = function (
   return {
     /**
      * Return a list of system prompts.
-     * @param {PromptsApiPromptsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     promptsList(
-      requestParameters: PromptsApiPromptsListRequest,
       options?: RawAxiosRequestConfig,
     ): AxiosPromise<Array<SystemPrompt>> {
       return localVarFp
-        .promptsList(requestParameters.prompt_name, options)
+        .promptsList(options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -2184,20 +2171,6 @@ export const PromptsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
   }
-}
-
-/**
- * Request parameters for promptsList operation in PromptsApi.
- * @export
- * @interface PromptsApiPromptsListRequest
- */
-export interface PromptsApiPromptsListRequest {
-  /**
-   * name of the system prompt
-   * @type {string}
-   * @memberof PromptsApiPromptsList
-   */
-  readonly prompt_name: string
 }
 
 /**
@@ -2223,17 +2196,13 @@ export interface PromptsApiPromptsRetrieveRequest {
 export class PromptsApi extends BaseAPI {
   /**
    * Return a list of system prompts.
-   * @param {PromptsApiPromptsListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PromptsApi
    */
-  public promptsList(
-    requestParameters: PromptsApiPromptsListRequest,
-    options?: RawAxiosRequestConfig,
-  ) {
+  public promptsList(options?: RawAxiosRequestConfig) {
     return PromptsApiFp(this.configuration)
-      .promptsList(requestParameters.prompt_name, options)
+      .promptsList(options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/frontend-demo/src/app/(home)/BaseChatContent.tsx
+++ b/frontend-demo/src/app/(home)/BaseChatContent.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useState } from "react"
+import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
+import Typography from "@mui/material/Typography"
+import Grid from "@mui/material/Grid2"
+import TextareaAutosize from "@mui/material/TextareaAutosize"
+import { FormLabel } from "@mui/material"
+import CircularProgress from "@mui/material/CircularProgress"
+import { Button } from "@mitodl/smoot-design"
+import { useQuery } from "@tanstack/react-query"
+import { promptQueries, userQueries } from "@/services/ai"
+import { useRequestOpts } from "./util"
+import AiChatDisplay from "./StyledAiChatDisplay"
+import SelectModel from "./SelectModel"
+import MetadataDisplay from "./MetadataDisplay"
+
+export interface BaseChatContentProps {
+  title: string
+  apiUrl: string
+  chatIdPrefix: string
+  conversationStarters?: AiChatProps["conversationStarters"]
+  initialMessages?: AiChatProps["initialMessages"]
+  promptQueryKey: string
+  promptSettingKey: string
+  modelSettingKey: string
+  isReady: boolean
+  extraBody: Record<string, unknown>
+  settings: Record<string, unknown>
+  setSettings: (patch: Record<string, unknown>) => void
+  sidebarContent?: React.ReactNode
+  children?: React.ReactNode
+  chatDisplayProps?: Partial<React.ComponentProps<typeof AiChatDisplay>>
+  showSystemPrompt?: boolean
+}
+
+const BaseChatContent: React.FC<BaseChatContentProps> = ({
+  title,
+  apiUrl,
+  chatIdPrefix,
+  conversationStarters = [],
+  initialMessages,
+  promptQueryKey,
+  promptSettingKey,
+  modelSettingKey,
+  isReady,
+  extraBody,
+  settings,
+  setSettings,
+  sidebarContent,
+  children,
+  chatDisplayProps = {},
+  showSystemPrompt = true,
+}) => {
+  const me = useQuery(userQueries.me())
+  const promptResult = useQuery({
+    ...promptQueries.get(promptQueryKey),
+    enabled: !!promptQueryKey,
+  })
+  const [promptText, setPromptText] = useState(
+    settings[promptSettingKey] as string,
+  )
+
+  useEffect(() => {
+    const nextValue = promptText || promptResult.data?.prompt_value || ""
+    if (nextValue === promptResult.data?.prompt_value) {
+      // If the prompt is identical to the default, don't send it in the request.
+      setSettings({ [promptSettingKey]: "" })
+    } else if (settings[promptSettingKey] !== promptText) {
+      setSettings({ [promptSettingKey]: nextValue })
+    }
+  }, [
+    promptText,
+    setSettings,
+    settings,
+    promptSettingKey,
+    promptResult.data?.prompt_value,
+  ])
+
+  const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
+    apiUrl,
+    extraBody,
+  })
+
+  const chatId = `${chatIdPrefix}-${chatSuffix}`
+
+  return (
+    <>
+      <Typography
+        variant="h3"
+        sx={(theme) => ({
+          color: theme.custom?.colors?.darkGray2,
+        })}
+      >
+        {title}
+      </Typography>
+      <AiChatProvider
+        chatId={chatId}
+        requestOpts={requestOpts}
+        initialMessages={initialMessages}
+      >
+        <Grid container spacing={2} sx={{ padding: 2 }}>
+          <Grid
+            size={{ xs: 12, md: 8 }}
+            sx={{ position: "relative", minHeight: "600px" }}
+            inert={!isReady}
+          >
+            {children || (
+              <AiChatDisplay
+                entryScreenEnabled={false}
+                conversationStarters={conversationStarters}
+                {...chatDisplayProps}
+              />
+            )}
+            {!isReady && (
+              <CircularProgress
+                color="primary"
+                sx={{
+                  position: "absolute",
+                  zIndex: 1000,
+                  top: "50%",
+                  left: "50%",
+                  transform: "translate(-50%, -50%)",
+                }}
+              />
+            )}
+          </Grid>
+          <Grid
+            size={{ xs: 12, md: 4 }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
+          >
+            {sidebarContent}
+            <SelectModel
+              value={settings[modelSettingKey] as string}
+              onChange={(e) => {
+                setSettings({ [modelSettingKey]: e.target.value })
+                requestNewThread()
+              }}
+            />
+            {showSystemPrompt && me.data?.is_staff ? (
+              <>
+                <FormLabel htmlFor={`${promptSettingKey}-ta`}>
+                  System Prompt
+                </FormLabel>
+                <TextareaAutosize
+                  id={`${promptSettingKey}-ta`}
+                  minRows={5}
+                  maxRows={15}
+                  value={promptText || promptResult.data?.prompt_value || ""}
+                  onChange={(e) => setPromptText(e.target.value)}
+                />
+              </>
+            ) : (
+              <></>
+            )}
+            <Button variant="secondary" onClick={requestNewThread}>
+              Start new thread
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <MetadataDisplay />
+          </Grid>
+        </Grid>
+      </AiChatProvider>
+    </>
+  )
+}
+
+export default BaseChatContent

--- a/frontend-demo/src/app/(home)/BaseChatContent.tsx
+++ b/frontend-demo/src/app/(home)/BaseChatContent.tsx
@@ -61,8 +61,9 @@ const BaseChatContent: React.FC<BaseChatContentProps> = ({
 
   useEffect(() => {
     const nextValue = promptText || promptResult.data?.prompt_value || ""
-    if (nextValue === promptResult.data?.prompt_value) {
-      // If the prompt is identical to the default, don't send it in the request.
+    if (nextValue === promptResult.data?.prompt_value || !me.data?.is_staff) {
+      // If the prompt is identical to the default, or user is not staff,
+      // don't send it in the request.
       setSettings({ [promptSettingKey]: "" })
     } else if (settings[promptSettingKey] !== promptText) {
       setSettings({ [promptSettingKey]: nextValue })

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -100,10 +100,11 @@ const RecommendationContent: React.FC = () => {
             />
             {me.data?.is_staff ? (
               <>
-                <FormLabel>System Prompt</FormLabel>
+                <FormLabel htmlFor="rec-prompt-ta">System Prompt</FormLabel>
                 <TextareaAutosize
-                  minRows={6}
-                  maxRows={10}
+                  id="rec-prompt-ta"
+                  minRows={5}
+                  maxRows={15}
                   value={promptText || promptResult.data?.prompt_value || ""}
                   onChange={(e) => setPromptText(e.target.value)}
                 />

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -1,15 +1,19 @@
+import { useEffect, useState } from "react"
 import { RECOMMENDATION_GPT_URL } from "@/services/ai/urls"
 import AiChatDisplay from "./StyledAiChatDisplay"
 import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
 import Typography from "@mui/material/Typography"
 import Grid from "@mui/material/Grid2"
+import TextareaAutosize from "@mui/material/TextareaAutosize"
+
 import SelectModel from "./SelectModel"
 import React from "react"
 import { useRequestOpts, useSearchParamSettings } from "./util"
 import SelectSearchURL from "./SelectSearchUrl"
 import MetadataDisplay from "./MetadataDisplay"
 import { Button } from "@mitodl/smoot-design"
-import SelectPrompt from "./SelectPrompt"
+import { promptQueries } from "@/services/ai"
+import { useQuery } from "@tanstack/react-query"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -21,8 +25,18 @@ const RecommendationContent: React.FC = () => {
   const [settings, setSettings] = useSearchParamSettings({
     rec_model: "",
     search_url: "",
-    systemPrompt: "",
+    systemPrompt: "initial",
   })
+
+  const promptResult = useQuery(promptQueries.get("recommendation"))
+  const [promptText, setPromptText] = useState(settings.systemPrompt)
+  useEffect(() => {
+    const nextValue =
+      promptText || promptText || promptResult.data?.prompt_value || ""
+    if (settings.systemPrompt !== nextValue) {
+      setSettings({ systemPrompt: nextValue })
+    }
+  }, [promptText, setSettings, settings.systemPrompt])
 
   const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
     apiUrl: RECOMMENDATION_GPT_URL,
@@ -34,13 +48,6 @@ const RecommendationContent: React.FC = () => {
   })
 
   const chatId = `recommendation-gpt-${chatSuffix}`
-  //const prompt = useQuery(promptQueries.get("recommendation"))
-
-  // React.useEffect(() => {
-  //   if (prompt.data?.prompt_value && !settings.system_prompt) {
-  //     setSettings({ system_prompt: prompt.data.prompt_value })
-  //   }
-  // }, [prompt.data, settings.system_prompt, setSettings])
 
   return (
     <>
@@ -82,12 +89,16 @@ const RecommendationContent: React.FC = () => {
               value={settings.search_url}
               onChange={(e) => setSettings({ search_url: e.target.value })}
             />
-            <SelectPrompt
-              value={settings.systemPrompt}
-              onChange={(e) => setSettings({ systemPrompt: e.target.value })}
+            <TextareaAutosize
+              aria-label="System Prompt"
               minRows={6}
-              maxRows={22}
-              style={{ width: "100%" }}
+              maxRows={10}
+              value={
+                promptText === "initial"
+                  ? promptResult.data?.prompt_value
+                  : promptText || ""
+              }
+              onChange={(e) => setPromptText(e.target.value)}
             />
             <Button variant="secondary" onClick={requestNewThread}>
               Start new thread

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -9,6 +9,7 @@ import { useRequestOpts, useSearchParamSettings } from "./util"
 import SelectSearchURL from "./SelectSearchUrl"
 import MetadataDisplay from "./MetadataDisplay"
 import { Button } from "@mitodl/smoot-design"
+import SelectPrompt from "./SelectPrompt"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -20,6 +21,7 @@ const RecommendationContent: React.FC = () => {
   const [settings, setSettings] = useSearchParamSettings({
     rec_model: "",
     search_url: "",
+    systemPrompt: "",
   })
 
   const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
@@ -27,10 +29,18 @@ const RecommendationContent: React.FC = () => {
     extraBody: {
       model: settings.rec_model,
       search_url: settings.search_url,
+      instructions: settings.systemPrompt,
     },
   })
 
   const chatId = `recommendation-gpt-${chatSuffix}`
+  //const prompt = useQuery(promptQueries.get("recommendation"))
+
+  // React.useEffect(() => {
+  //   if (prompt.data?.prompt_value && !settings.system_prompt) {
+  //     setSettings({ system_prompt: prompt.data.prompt_value })
+  //   }
+  // }, [prompt.data, settings.system_prompt, setSettings])
 
   return (
     <>
@@ -71,6 +81,13 @@ const RecommendationContent: React.FC = () => {
             <SelectSearchURL
               value={settings.search_url}
               onChange={(e) => setSettings({ search_url: e.target.value })}
+            />
+            <SelectPrompt
+              value={settings.systemPrompt}
+              onChange={(e) => setSettings({ systemPrompt: e.target.value })}
+              minRows={6}
+              maxRows={22}
+              style={{ width: "100%" }}
             />
             <Button variant="secondary" onClick={requestNewThread}>
               Start new thread

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -1,20 +1,9 @@
-import { useEffect, useState } from "react"
-import { RECOMMENDATION_GPT_URL } from "@/services/ai/urls"
-import AiChatDisplay from "./StyledAiChatDisplay"
-import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
-import Typography from "@mui/material/Typography"
-import Grid from "@mui/material/Grid2"
-import TextareaAutosize from "@mui/material/TextareaAutosize"
-
-import SelectModel from "./SelectModel"
 import React from "react"
-import { useRequestOpts, useSearchParamSettings } from "./util"
+import { RECOMMENDATION_GPT_URL } from "@/services/ai/urls"
+import { type AiChatProps } from "@mitodl/smoot-design/ai"
+import { useSearchParamSettings } from "./util"
 import SelectSearchURL from "./SelectSearchUrl"
-import MetadataDisplay from "./MetadataDisplay"
-import { Button } from "@mitodl/smoot-design"
-import { promptQueries, userQueries } from "@/services/ai"
-import { useQuery } from "@tanstack/react-query"
-import { FormLabel } from "@mui/material"
+import BaseChatContent from "./BaseChatContent"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -29,99 +18,30 @@ const RecommendationContent: React.FC = () => {
     rec_prompt: "",
   })
 
-  const me = useQuery(userQueries.me())
-  const promptResult = useQuery(promptQueries.get("recommendation"))
-  const [promptText, setPromptText] = useState(settings.rec_prompt)
-  useEffect(() => {
-    const nextValue = promptText || promptResult.data?.prompt_value || ""
-    if (nextValue === promptResult.data?.prompt_value) {
-      // If the prompt is identical to the default, don't send it in the request.
-      setSettings({ rec_prompt: "" })
-    } else if (settings.rec_prompt !== promptText) {
-      setSettings({ rec_prompt: nextValue })
-    }
-  }, [
-    promptText,
-    setSettings,
-    settings.rec_prompt,
-    promptResult.data?.prompt_value,
-  ])
-
-  const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
-    apiUrl: RECOMMENDATION_GPT_URL,
-    extraBody: {
-      model: settings.rec_model,
-      search_url: settings.search_url,
-      instructions: settings.rec_prompt,
-    },
-  })
-
-  const chatId = `recommendation-gpt-${chatSuffix}`
-
   return (
-    <>
-      <Typography
-        variant="h3"
-        sx={(theme) => ({
-          color: theme.custom.colors.darkGray2,
-        })}
-      >
-        RecommendationGPT
-      </Typography>
-      <AiChatProvider chatId={chatId} requestOpts={requestOpts}>
-        <Grid container spacing={2} sx={{ padding: 2 }}>
-          <Grid
-            size={{ xs: 12, md: 8 }}
-            sx={{ position: "relative", minHeight: "600px" }}
-          >
-            <AiChatDisplay
-              entryScreenEnabled={false}
-              conversationStarters={CONVERSATION_STARTERS}
-            />
-          </Grid>
-          <Grid
-            size={{ xs: 12, md: 4 }}
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "16px",
-            }}
-          >
-            <SelectModel
-              value={settings.rec_model}
-              onChange={(e) => {
-                setSettings({ rec_model: e.target.value })
-                requestNewThread()
-              }}
-            />
-            <SelectSearchURL
-              value={settings.search_url}
-              onChange={(e) => setSettings({ search_url: e.target.value })}
-            />
-            {me.data?.is_staff ? (
-              <>
-                <FormLabel htmlFor="rec-prompt-ta">System Prompt</FormLabel>
-                <TextareaAutosize
-                  id="rec-prompt-ta"
-                  minRows={5}
-                  maxRows={15}
-                  value={promptText || promptResult.data?.prompt_value || ""}
-                  onChange={(e) => setPromptText(e.target.value)}
-                />
-              </>
-            ) : (
-              <></>
-            )}
-            <Button variant="secondary" onClick={requestNewThread}>
-              Start new thread
-            </Button>
-          </Grid>
-          <Grid size={{ xs: 12 }}>
-            <MetadataDisplay />
-          </Grid>
-        </Grid>
-      </AiChatProvider>
-    </>
+    <BaseChatContent
+      title="RecommendationGPT"
+      apiUrl={RECOMMENDATION_GPT_URL}
+      chatIdPrefix="recommendation-gpt"
+      conversationStarters={CONVERSATION_STARTERS}
+      promptQueryKey="recommendation"
+      promptSettingKey="rec_prompt"
+      modelSettingKey="rec_model"
+      isReady={true}
+      extraBody={{
+        model: settings.rec_model,
+        search_url: settings.search_url,
+        instructions: settings.rec_prompt,
+      }}
+      settings={settings}
+      setSettings={setSettings}
+      sidebarContent={
+        <SelectSearchURL
+          value={settings.search_url}
+          onChange={(e) => setSettings({ search_url: e.target.value })}
+        />
+      }
+    />
   )
 }
 

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -40,7 +40,12 @@ const RecommendationContent: React.FC = () => {
     } else if (settings.rec_prompt !== promptText) {
       setSettings({ rec_prompt: nextValue })
     }
-  }, [promptText, setSettings, settings.rec_prompt])
+  }, [
+    promptText,
+    setSettings,
+    settings.rec_prompt,
+    promptResult.data?.prompt_value,
+  ])
 
   const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
     apiUrl: RECOMMENDATION_GPT_URL,
@@ -93,14 +98,16 @@ const RecommendationContent: React.FC = () => {
               value={settings.search_url}
               onChange={(e) => setSettings({ search_url: e.target.value })}
             />
-            <FormLabel>System Prompt</FormLabel>
             {me.data?.is_staff ? (
-              <TextareaAutosize
-                minRows={6}
-                maxRows={10}
-                value={promptText || promptResult.data?.prompt_value || ""}
-                onChange={(e) => setPromptText(e.target.value)}
-              />
+              <>
+                <FormLabel>System Prompt</FormLabel>
+                <TextareaAutosize
+                  minRows={6}
+                  maxRows={10}
+                  value={promptText || promptResult.data?.prompt_value || ""}
+                  onChange={(e) => setPromptText(e.target.value)}
+                />
+              </>
             ) : (
               <></>
             )}

--- a/frontend-demo/src/app/(home)/RecommendationContent.tsx
+++ b/frontend-demo/src/app/(home)/RecommendationContent.tsx
@@ -12,8 +12,9 @@ import { useRequestOpts, useSearchParamSettings } from "./util"
 import SelectSearchURL from "./SelectSearchUrl"
 import MetadataDisplay from "./MetadataDisplay"
 import { Button } from "@mitodl/smoot-design"
-import { promptQueries } from "@/services/ai"
+import { promptQueries, userQueries } from "@/services/ai"
 import { useQuery } from "@tanstack/react-query"
+import { FormLabel } from "@mui/material"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -25,25 +26,28 @@ const RecommendationContent: React.FC = () => {
   const [settings, setSettings] = useSearchParamSettings({
     rec_model: "",
     search_url: "",
-    systemPrompt: "initial",
+    rec_prompt: "",
   })
 
+  const me = useQuery(userQueries.me())
   const promptResult = useQuery(promptQueries.get("recommendation"))
-  const [promptText, setPromptText] = useState(settings.systemPrompt)
+  const [promptText, setPromptText] = useState(settings.rec_prompt)
   useEffect(() => {
-    const nextValue =
-      promptText || promptText || promptResult.data?.prompt_value || ""
-    if (settings.systemPrompt !== nextValue) {
-      setSettings({ systemPrompt: nextValue })
+    const nextValue = promptText || promptResult.data?.prompt_value || ""
+    if (nextValue === promptResult.data?.prompt_value) {
+      // If the prompt is identical to the default, don't send it in the request.
+      setSettings({ rec_prompt: "" })
+    } else if (settings.rec_prompt !== promptText) {
+      setSettings({ rec_prompt: nextValue })
     }
-  }, [promptText, setSettings, settings.systemPrompt])
+  }, [promptText, setSettings, settings.rec_prompt])
 
   const { requestOpts, requestNewThread, chatSuffix } = useRequestOpts({
     apiUrl: RECOMMENDATION_GPT_URL,
     extraBody: {
       model: settings.rec_model,
       search_url: settings.search_url,
-      instructions: settings.systemPrompt,
+      instructions: settings.rec_prompt,
     },
   })
 
@@ -89,17 +93,17 @@ const RecommendationContent: React.FC = () => {
               value={settings.search_url}
               onChange={(e) => setSettings({ search_url: e.target.value })}
             />
-            <TextareaAutosize
-              aria-label="System Prompt"
-              minRows={6}
-              maxRows={10}
-              value={
-                promptText === "initial"
-                  ? promptResult.data?.prompt_value
-                  : promptText || ""
-              }
-              onChange={(e) => setPromptText(e.target.value)}
-            />
+            <FormLabel>System Prompt</FormLabel>
+            {me.data?.is_staff ? (
+              <TextareaAutosize
+                minRows={6}
+                maxRows={10}
+                value={promptText || promptResult.data?.prompt_value || ""}
+                onChange={(e) => setPromptText(e.target.value)}
+              />
+            ) : (
+              <></>
+            )}
             <Button variant="secondary" onClick={requestNewThread}>
               Start new thread
             </Button>

--- a/frontend-demo/src/app/(home)/SelectPrompt.tsx
+++ b/frontend-demo/src/app/(home)/SelectPrompt.tsx
@@ -1,0 +1,24 @@
+import TextareaAutosize from "@mui/material/TextareaAutosize"
+import type { TextareaAutosizeProps } from "@mui/material/TextareaAutosize"
+import { promptQueries } from "@/services/ai"
+import { useQuery } from "@tanstack/react-query"
+
+const SelectPrompt: React.FC<
+  TextareaAutosizeProps & {
+    value: string
+  }
+> = (props) => {
+  const prompt = useQuery(promptQueries.get("recommendation"))
+  return (
+    <TextareaAutosize
+      aria-label="System Prompt"
+      {...props}
+      /**
+       * Avoid passing an out-of-range value while the options are loading.
+       */
+      value={prompt.isLoading ? "" : props.value}
+    />
+  )
+}
+
+export default SelectPrompt

--- a/frontend-demo/src/app/(home)/SyllabusContent.tsx
+++ b/frontend-demo/src/app/(home)/SyllabusContent.tsx
@@ -111,7 +111,12 @@ const SyllabusContent = () => {
     } else if (settings.syllabus_prompt !== promptText) {
       setSettings({ syllabus_prompt: nextValue })
     }
-  }, [promptText, setSettings, settings.syllabus_prompt])
+  }, [
+    promptText,
+    setSettings,
+    settings.syllabus_prompt,
+    promptResult.data?.prompt_value,
+  ])
 
   const resourceId = Number.isFinite(+settings.syllabus_resource)
     ? +settings.syllabus_resource
@@ -191,14 +196,16 @@ const SyllabusContent = () => {
               error={!!resourceParseError || resource.isError}
               helperText={getResourceHelpText(resourceParseError, resource)}
             />
-            <FormLabel>System Prompt</FormLabel>
             {me.data?.is_staff ? (
-              <TextareaAutosize
-                minRows={6}
-                maxRows={10}
-                value={promptText || promptResult.data?.prompt_value || ""}
-                onChange={(e) => setPromptText(e.target.value)}
-              />
+              <>
+                <FormLabel>System Prompt</FormLabel>
+                <TextareaAutosize
+                  minRows={6}
+                  maxRows={10}
+                  value={promptText || promptResult.data?.prompt_value || ""}
+                  onChange={(e) => setPromptText(e.target.value)}
+                />
+              </>
             ) : (
               <></>
             )}

--- a/frontend-demo/src/app/(home)/SyllabusContent.tsx
+++ b/frontend-demo/src/app/(home)/SyllabusContent.tsx
@@ -1,22 +1,13 @@
+import { useEffect, useState } from "react"
 import { SYLLABUS_GPT_URL } from "@/services/ai/urls"
-import AiChatDisplay from "./StyledAiChatDisplay"
-import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
+import { type AiChatProps } from "@mitodl/smoot-design/ai"
 import Link from "@mui/material/Link"
-import Typography from "@mui/material/Typography"
-import Grid from "@mui/material/Grid2"
 import TextField from "@mui/material/TextField"
-import TextareaAutosize from "@mui/material/TextareaAutosize"
-import SelectModel from "./SelectModel"
-import { useRequestOpts, useSearchParamSettings } from "./util"
+import { useSearchParamSettings } from "./util"
 import { useQuery, UseQueryResult } from "@tanstack/react-query"
 import { learningResourcesQueries } from "@/services/learn"
 import { LearningResource } from "@mitodl/mit-learn-api-axios/v1"
-import { useEffect, useState } from "react"
-import CircularProgress from "@mui/material/CircularProgress"
-import MetadataDisplay from "./MetadataDisplay"
-import { Button } from "@mitodl/smoot-design"
-import { promptQueries, userQueries } from "@/services/ai"
-import { FormLabel } from "@mui/material"
+import BaseChatContent from "./BaseChatContent"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = [
   {
@@ -100,24 +91,6 @@ const SyllabusContent = () => {
     }
   }, [resourceText, setSettings, settings.syllabus_resource])
 
-  const me = useQuery(userQueries.me())
-  const promptResult = useQuery(promptQueries.get("syllabus"))
-  const [promptText, setPromptText] = useState(settings.syllabus_prompt)
-  useEffect(() => {
-    const nextValue = promptText || promptResult.data?.prompt_value || ""
-    if (nextValue === promptResult.data?.prompt_value) {
-      // If the prompt is identical to the default, don't send it in the request.
-      setSettings({ syllabus_prompt: "" })
-    } else if (settings.syllabus_prompt !== promptText) {
-      setSettings({ syllabus_prompt: nextValue })
-    }
-  }, [
-    promptText,
-    setSettings,
-    settings.syllabus_prompt,
-    promptResult.data?.prompt_value,
-  ])
-
   const resourceId = Number.isFinite(+settings.syllabus_resource)
     ? +settings.syllabus_resource
     : -1
@@ -125,103 +98,47 @@ const SyllabusContent = () => {
     ...learningResourcesQueries.retrieve({ id: resourceId }),
     enabled: !!resourceId,
   })
-  const { requestOpts, chatSuffix, requestNewThread } = useRequestOpts({
-    apiUrl: SYLLABUS_GPT_URL,
-    extraBody: {
-      model: settings.syllabus_model,
-      course_id: resource.data?.readable_id,
-      related_resources: Array.isArray(resource.data?.children)
-        ? resource.data.children.map((child) => child.readable_id)
-        : undefined,
-      instructions: settings.syllabus_prompt,
-    },
-  })
 
   const isReady = resource.isSuccess
-  const chatId = `syllabus-gpt-${chatSuffix}`
+
   return (
-    <>
-      <Typography variant="h3">SyllabusGPT</Typography>
-      <AiChatProvider chatId={chatId} requestOpts={requestOpts}>
-        <Grid container spacing={2} sx={{ padding: 2 }}>
-          <Grid
-            size={{ xs: 12, md: 8 }}
-            sx={{ position: "relative", minHeight: "600px" }}
-            inert={!isReady}
-          >
-            <AiChatDisplay
-              entryScreenEnabled={false}
-              conversationStarters={CONVERSATION_STARTERS}
-            />
-            {!isReady && (
-              <CircularProgress
-                color="primary"
-                sx={{
-                  position: "absolute",
-                  zIndex: 1000,
-                  top: "50%",
-                  left: "50%",
-                  transform: "translate(-50%, -50%)",
-                }}
-              />
-            )}
-          </Grid>
-          <Grid
-            size={{ xs: 12, md: 4 }}
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "16px",
-            }}
-          >
-            <SelectModel
-              value={settings.syllabus_model}
-              onChange={(e) => {
-                setSettings({ syllabus_model: e.target.value })
-                requestNewThread()
-              }}
-            />
-            <TextField
-              size="small"
-              margin="normal"
-              label="Resource ID or Learn Resource URL"
-              fullWidth
-              /**
-               * don't use settings.syllabus_resource directly here to avoid
-               * so that we can keep the updates syncrhonous to avoid
-               * https://stackoverflow.com/questions/46000544/react-controlled-input-cursor-jumps
-               */
-              value={resourceText}
-              onChange={(e) => setResourceText(e.target.value)}
-              error={!!resourceParseError || resource.isError}
-              helperText={getResourceHelpText(resourceParseError, resource)}
-            />
-            {me.data?.is_staff ? (
-              <>
-                <FormLabel htmlFor="syllabus-prompt-ta">
-                  System Prompt
-                </FormLabel>
-                <TextareaAutosize
-                  id="syllabus-prompt-ta"
-                  minRows={5}
-                  maxRows={15}
-                  value={promptText || promptResult.data?.prompt_value || ""}
-                  onChange={(e) => setPromptText(e.target.value)}
-                />
-              </>
-            ) : (
-              <></>
-            )}
-            <Button variant="secondary" onClick={requestNewThread}>
-              Start new thread
-            </Button>
-          </Grid>
-          <Grid size={{ xs: 12 }}>
-            <MetadataDisplay />
-          </Grid>
-        </Grid>
-      </AiChatProvider>
-    </>
+    <BaseChatContent
+      title="SyllabusGPT"
+      apiUrl={SYLLABUS_GPT_URL}
+      chatIdPrefix="syllabus-gpt"
+      conversationStarters={CONVERSATION_STARTERS}
+      promptQueryKey="syllabus"
+      promptSettingKey="syllabus_prompt"
+      modelSettingKey="syllabus_model"
+      isReady={isReady}
+      extraBody={{
+        model: settings.syllabus_model,
+        course_id: resource.data?.readable_id,
+        related_resources: Array.isArray(resource.data?.children)
+          ? resource.data.children.map((child) => child.readable_id)
+          : undefined,
+        instructions: settings.syllabus_prompt,
+      }}
+      settings={settings}
+      setSettings={setSettings}
+      sidebarContent={
+        <TextField
+          size="small"
+          margin="normal"
+          label="Resource ID or Learn Resource URL"
+          fullWidth
+          /**
+           * don't use settings.syllabus_resource directly here to avoid
+           * so that we can keep the updates syncrhonous to avoid
+           * https://stackoverflow.com/questions/46000544/react-controlled-input-cursor-jumps
+           */
+          value={resourceText}
+          onChange={(e) => setResourceText(e.target.value)}
+          error={!!resourceParseError || resource.isError}
+          helperText={getResourceHelpText(resourceParseError, resource)}
+        />
+      }
+    />
   )
 }
 

--- a/frontend-demo/src/app/(home)/SyllabusContent.tsx
+++ b/frontend-demo/src/app/(home)/SyllabusContent.tsx
@@ -198,10 +198,13 @@ const SyllabusContent = () => {
             />
             {me.data?.is_staff ? (
               <>
-                <FormLabel>System Prompt</FormLabel>
+                <FormLabel htmlFor="syllabus-prompt-ta">
+                  System Prompt
+                </FormLabel>
                 <TextareaAutosize
-                  minRows={6}
-                  maxRows={10}
+                  id="syllabus-prompt-ta"
+                  minRows={5}
+                  maxRows={15}
                   value={promptText || promptResult.data?.prompt_value || ""}
                   onChange={(e) => setPromptText(e.target.value)}
                 />

--- a/frontend-demo/src/app/(home)/VideoContent.tsx
+++ b/frontend-demo/src/app/(home)/VideoContent.tsx
@@ -1,22 +1,13 @@
+import { useMemo } from "react"
 import { VIDEO_GPT_URL } from "@/services/ai/urls"
-import AiChatDisplay from "./StyledAiChatDisplay"
-import { AiChatProvider, type AiChatProps } from "@mitodl/smoot-design/ai"
-import Typography from "@mui/material/Typography"
-import Grid from "@mui/material/Grid2"
-import SelectModel from "./SelectModel"
-import { useRequestOpts, useSearchParamSettings } from "./util"
-
+import { type AiChatProps } from "@mitodl/smoot-design/ai"
+import { useSearchParamSettings } from "./util"
 import { useQuery } from "@tanstack/react-query"
 import OpenEdxLoginAlert from "./OpenedxLoginAlert"
-
 import Alert from "@mui/lab/Alert"
-import { useEffect, useMemo, useState } from "react"
-
 import OpenedxUnitSelectionForm from "./OpenedxUnitSelectionForm"
-import { CircularProgress, FormLabel, TextareaAutosize } from "@mui/material"
-import MetadataDisplay from "./MetadataDisplay"
-import { Button } from "@mitodl/smoot-design"
-import { promptQueries, userQueries } from "@/services/ai"
+import Typography from "@mui/material/Typography"
+import BaseChatContent from "./BaseChatContent"
 
 const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = []
 const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
@@ -36,24 +27,6 @@ const VideoContent = () => {
     video_unit: DEFAULT_VIDEO,
     video_prompt: "",
   })
-
-  const me = useQuery(userQueries.me())
-  const promptResult = useQuery(promptQueries.get("video_gpt"))
-  const [promptText, setPromptText] = useState(settings.video_prompt)
-  useEffect(() => {
-    const nextValue = promptText || promptResult.data?.prompt_value || ""
-    if (nextValue === promptResult.data?.prompt_value) {
-      // If the prompt is identical to the default, don't send it in the request.
-      setSettings({ video_prompt: "" })
-    } else if (settings.video_prompt !== nextValue) {
-      setSettings({ video_prompt: nextValue })
-    }
-  }, [
-    promptText,
-    setSettings,
-    settings.video_prompt,
-    promptResult.data?.prompt_value,
-  ])
 
   const getTranscriptBlockId = async (edxModuleId: string) => {
     const response = await fetch(
@@ -76,114 +49,57 @@ const VideoContent = () => {
     return { id: transcriptIdQueryResult.data.transcript_block_id, error: null }
   }, [transcriptIdQueryResult])
 
-  const { requestOpts, chatSuffix, requestNewThread } = useRequestOpts({
-    apiUrl: VIDEO_GPT_URL,
-    extraBody: {
-      model: settings.video_model,
-      transcript_asset_id: transcriptBlockId,
-      edx_module_id: settings.video_unit,
-      instructions: settings.video_prompt,
-    },
-  })
   const isReady = !!transcriptBlockId
-  const chatId = `video-gpt-${chatSuffix}`
+
   return (
-    <>
-      <Typography variant="h3">VideoGPT</Typography>
-      <AiChatProvider
-        chatId={chatId}
-        initialMessages={INITIAL_MESSAGES}
-        requestOpts={requestOpts}
-      >
-        <Grid container spacing={2} sx={{ padding: 2 }}>
-          <Grid
-            size={{ xs: 12, md: 8 }}
-            sx={{ position: "relative", minHeight: "600px" }}
-            inert={!isReady}
-          >
-            <AiChatDisplay
-              entryScreenEnabled={false}
-              conversationStarters={CONVERSATION_STARTERS}
-            />
-            {!isReady && (
-              <CircularProgress
-                color="primary"
-                sx={{
-                  position: "absolute",
-                  zIndex: 1000,
-                  top: "50%",
-                  left: "50%",
-                  transform: "translate(-50%, -50%)",
-                }}
-              />
-            )}
-          </Grid>
-          <Grid
-            size={{ xs: 12, md: 4 }}
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "16px",
+    <BaseChatContent
+      title="VideoGPT"
+      apiUrl={VIDEO_GPT_URL}
+      chatIdPrefix="video-gpt"
+      conversationStarters={CONVERSATION_STARTERS}
+      initialMessages={INITIAL_MESSAGES}
+      promptQueryKey="video_gpt"
+      promptSettingKey="video_prompt"
+      modelSettingKey="video_model"
+      isReady={isReady}
+      extraBody={{
+        model: settings.video_model,
+        transcript_asset_id: transcriptBlockId,
+        edx_module_id: settings.video_unit,
+        instructions: settings.video_prompt,
+      }}
+      settings={settings}
+      setSettings={setSettings}
+      sidebarContent={
+        <>
+          <OpenEdxLoginAlert />
+          <OpenedxUnitSelectionForm
+            selectedVertical={settings.video_vertical}
+            selectedUnit={settings.video_unit}
+            defaultUnit={settings.video_unit}
+            defaultVertical={settings.video_vertical}
+            onSubmit={(values) => {
+              setSettings({
+                video_unit: values.unit,
+                video_vertical: values.vertical,
+              })
             }}
-          >
-            <OpenEdxLoginAlert />
-            <SelectModel
-              value={settings.video_model}
-              onChange={(e) => {
-                setSettings({ video_model: e.target.value })
-                requestNewThread()
-              }}
-            />
-            <OpenedxUnitSelectionForm
-              selectedVertical={settings.video_vertical}
-              selectedUnit={settings.video_unit}
-              defaultUnit={settings.video_unit}
-              defaultVertical={settings.video_vertical}
-              onSubmit={(values) => {
-                setSettings({
-                  video_unit: values.unit,
-                  video_vertical: values.vertical,
-                })
-              }}
-              onReset={() => {
-                setSettings({
-                  video_unit: null,
-                  video_vertical: null,
-                })
-              }}
-              unitFilterType="video"
-              unitLabel="Video"
-            />
-            {transcriptIdQueryResult.isLoading && (
-              <Typography>Loading...</Typography>
-            )}
-            {transcriptError && (
-              <Alert severity="error">{transcriptError}</Alert>
-            )}
-            {me.data?.is_staff ? (
-              <>
-                <FormLabel htmlFor="video-prompt-ta">System Prompt</FormLabel>
-                <TextareaAutosize
-                  id="video-prompt-ta"
-                  minRows={5}
-                  maxRows={15}
-                  value={promptText || promptResult.data?.prompt_value || ""}
-                  onChange={(e) => setPromptText(e.target.value)}
-                />
-              </>
-            ) : (
-              <></>
-            )}
-            <Button variant="secondary" onClick={requestNewThread}>
-              Start new thread
-            </Button>
-          </Grid>
-          <Grid size={{ xs: 12 }}>
-            <MetadataDisplay />
-          </Grid>
-        </Grid>
-      </AiChatProvider>
-    </>
+            onReset={() => {
+              setSettings({
+                video_unit: null,
+                video_vertical: null,
+              })
+            }}
+            unitFilterType="video"
+            unitLabel="Video"
+          />
+          {transcriptIdQueryResult.isLoading && (
+            <Typography>Loading...</Typography>
+          )}
+          {transcriptError && <Alert severity="error">{transcriptError}</Alert>}
+        </>
+      }
+    />
   )
 }
 

--- a/frontend-demo/src/app/(home)/VideoContent.tsx
+++ b/frontend-demo/src/app/(home)/VideoContent.tsx
@@ -41,8 +41,7 @@ const VideoContent = () => {
   const promptResult = useQuery(promptQueries.get("video_gpt"))
   const [promptText, setPromptText] = useState(settings.video_prompt)
   useEffect(() => {
-    const nextValue =
-      promptText || promptText || promptResult.data?.prompt_value || ""
+    const nextValue = promptText || promptResult.data?.prompt_value || ""
     if (nextValue === promptResult.data?.prompt_value) {
       // If the prompt is identical to the default, don't send it in the request.
       setSettings({ video_prompt: "" })
@@ -163,10 +162,11 @@ const VideoContent = () => {
             )}
             {me.data?.is_staff ? (
               <>
-                <FormLabel>System Prompt</FormLabel>
+                <FormLabel htmlFor="video-prompt-ta">System Prompt</FormLabel>
                 <TextareaAutosize
-                  minRows={6}
-                  maxRows={10}
+                  id="video-prompt-ta"
+                  minRows={5}
+                  maxRows={15}
                   value={promptText || promptResult.data?.prompt_value || ""}
                   onChange={(e) => setPromptText(e.target.value)}
                 />

--- a/frontend-demo/src/app/(home)/VideoContent.tsx
+++ b/frontend-demo/src/app/(home)/VideoContent.tsx
@@ -13,7 +13,7 @@ import Alert from "@mui/lab/Alert"
 import { useEffect, useMemo, useState } from "react"
 
 import OpenedxUnitSelectionForm from "./OpenedxUnitSelectionForm"
-import { CircularProgress, TextareaAutosize } from "@mui/material"
+import { CircularProgress, FormLabel, TextareaAutosize } from "@mui/material"
 import MetadataDisplay from "./MetadataDisplay"
 import { Button } from "@mitodl/smoot-design"
 import { promptQueries, userQueries } from "@/services/ai"
@@ -49,7 +49,12 @@ const VideoContent = () => {
     } else if (settings.video_prompt !== nextValue) {
       setSettings({ video_prompt: nextValue })
     }
-  }, [promptText, setSettings, settings.video_prompt])
+  }, [
+    promptText,
+    setSettings,
+    settings.video_prompt,
+    promptResult.data?.prompt_value,
+  ])
 
   const getTranscriptBlockId = async (edxModuleId: string) => {
     const response = await fetch(
@@ -157,13 +162,15 @@ const VideoContent = () => {
               <Alert severity="error">{transcriptError}</Alert>
             )}
             {me.data?.is_staff ? (
-              <TextareaAutosize
-                aria-label="System Prompt"
-                minRows={6}
-                maxRows={10}
-                value={promptText || promptResult.data?.prompt_value || ""}
-                onChange={(e) => setPromptText(e.target.value)}
-              />
+              <>
+                <FormLabel>System Prompt</FormLabel>
+                <TextareaAutosize
+                  minRows={6}
+                  maxRows={10}
+                  value={promptText || promptResult.data?.prompt_value || ""}
+                  onChange={(e) => setPromptText(e.target.value)}
+                />
+              </>
             ) : (
               <></>
             )}

--- a/frontend-demo/src/services/ai/index.ts
+++ b/frontend-demo/src/services/ai/index.ts
@@ -1,2 +1,3 @@
 export { queries as llmModelsQueries } from "./llm-models/queries"
 export { queries as userQueries } from "./user/queries"
+export { queries as promptQueries } from "./prompts/queries"

--- a/frontend-demo/src/services/ai/prompts/queries.ts
+++ b/frontend-demo/src/services/ai/prompts/queries.ts
@@ -1,0 +1,29 @@
+import { queryOptions } from "@tanstack/react-query"
+import { getAPISettings } from "../settings"
+import { PromptsApi } from "@api/v0"
+
+const promptsApi = new PromptsApi(...getAPISettings())
+
+const keys = {
+  root: () => ["prompts"],
+  list: () => [...keys.root(), "list"],
+  get: (promptName: string) => [...keys.root(), "get", promptName],
+}
+
+const queries = {
+  list: () =>
+    queryOptions({
+      queryKey: keys.list(),
+      queryFn: () => promptsApi.promptsList().then((res) => res.data),
+    }),
+  get: (promptName: string) =>
+    queryOptions({
+      queryKey: keys.get(promptName),
+      queryFn: () =>
+        promptsApi
+          .promptsRetrieve({ prompt_name: promptName })
+          .then((res) => res.data),
+    }),
+}
+
+export { queries }

--- a/frontend-demo/src/services/ai/user/queries.ts
+++ b/frontend-demo/src/services/ai/user/queries.ts
@@ -9,6 +9,8 @@ const keys = {
 type UserResponse = {
   username?: string
   anonymous?: boolean
+  is_staff?: boolean
+  is_superuser?: boolean
 }
 
 const queries = {

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -232,6 +232,13 @@ paths:
     get:
       operationId: prompts_list
       description: Return a list of system prompts.
+      parameters:
+      - in: path
+        name: prompt_name
+        schema:
+          type: string
+        description: name of the system prompt
+        required: true
       tags:
       - prompts
       security:
@@ -254,6 +261,7 @@ paths:
         name: prompt_name
         schema:
           type: string
+        description: name of the system prompt
         required: true
       tags:
       - prompts

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -228,6 +228,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/LLMModel'
           description: ''
+  /api/v0/prompts/:
+    get:
+      operationId: prompts_list
+      description: Return a list of system prompts.
+      tags:
+      - prompts
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SystemPrompt'
+          description: ''
+  /api/v0/prompts/{prompt_name}/:
+    get:
+      operationId: prompts_retrieve
+      description: Return a specific system prompt.
+      parameters:
+      - in: path
+        name: prompt_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - prompts
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemPrompt'
+          description: ''
   /http/recommendation_agent/:
     post:
       operationId: RecommendationAgentV0
@@ -404,6 +442,17 @@ components:
         title:
           type: string
           maxLength: 255
+    SystemPrompt:
+      type: object
+      description: Serializer for system prompts
+      properties:
+        prompt_name:
+          type: string
+        prompt_value:
+          type: string
+      required:
+      - prompt_name
+      - prompt_value
     UserChatSession:
       type: object
       description: Serializer for user chat sessions

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -232,13 +232,6 @@ paths:
     get:
       operationId: prompts_list
       description: Return a list of system prompts.
-      parameters:
-      - in: path
-        name: prompt_name
-        schema:
-          type: string
-        description: name of the system prompt
-        required: true
       tags:
       - prompts
       security:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7506

### Description (What does it do?)
- Adds an API endpoint for retrieving the system prompts of 3 chatbot agents (recommendation, syllabus, video GPT)
- Modifies the recommendation, syllabus, and video chatbot tabs to include a textarea field for sending a custom system prompt to each chatbot.  The field is prepopulated with the default prompt on load. 

### How can this be tested?
Backend:
- Go to http://ai.open.odl.local:8005/api/v0/prompts/ - you should get a list of prompts for 3 chatbots (names and values)
- Go to http://ai.open.odl.local:8005/api/v0/prompts/syllabus/ - you should get the prompt name/value for the syllabus bot
- Go to http://ai.open.odl.local:8005/api/v0/prompts/fake/ - you should get a 404
- The endpoint should be included at http://ai.open.odl.local:8005/api/v0/schema/swagger-ui/

Frontend: 
- As an unauthenticated or non-staff member, try each of the 3 chatbot tabs, they should look and act the same as ever, with no changes.
- Log in via keycloak as a staff user.  Try the chatbots again, this time there should be a system prompt field that is populated with the default system prompt on load, and again whenever you clear out the value completely.
- Modify the prompts and send messages to the chatbots.  An easy way to tell if the prompt was used by the chatbot is to change the prompt to something like "Speak like a pirate" or "Speak like Yoda"
- If you clear the prompt completely, the default prompt should return.



