### PR TITLE
limit message length

### DIFF
--- a/ai_chatbots/serializers_test.py
+++ b/ai_chatbots/serializers_test.py
@@ -1,6 +1,7 @@
 """Tests for serializers"""
 
 import pytest
+from django.conf import settings
 
 from ai_chatbots.serializers import ChatRequestSerializer
 from main.factories import UserFactory
@@ -24,3 +25,21 @@ def test_instructions_permissions(is_staff, is_super):
         context={"user": user},
     )
     assert serializer.is_valid() == (is_staff or is_super)
+
+
+@pytest.mark.django_db
+def test_message_truncation():
+    """Test that the message field truncates correctly."""
+    user = UserFactory.create(is_staff=True)
+
+    settings.AI_MAX_MESSAGE_LENGTH = 6000
+
+    long_message = "x" * (
+        settings.AI_MAX_MESSAGE_LENGTH + 1000
+    )  # Exceeds the max length
+    serializer = ChatRequestSerializer(
+        data={"message": long_message, "instructions": "Do something"},
+        context={"user": user},
+    )
+    assert serializer.is_valid()
+    assert len(serializer.validated_data["message"]) == settings.AI_MAX_MESSAGE_LENGTH

--- a/main/settings.py
+++ b/main/settings.py
@@ -687,7 +687,9 @@ AI_MAX_TOKEN_BIND = get_int(name="AI_MAX_TOKEN_BIND", default=16384)
 AI_PROMPT_CACHE_DURATION = get_int(
     name="AI_PROMPT_CACHE_DURATION", default=60 * 60 * 24 * 28
 )  # 28 days
-
+AI_MAX_MESSAGE_LENGTH = get_int(
+    name="AI_MAX_MESSAGE_LENGTH", default=6000
+)  # Maximum length of a message in characters
 # AI proxy settings (aka LiteLLM)
 AI_PROXY_CLASS = get_string(name="AI_PROXY_CLASS", default="")
 AI_PROXY_URL = get_string(name="AI_PROXY_URL", default="")


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7620

### Description (What does it do?)
Users can create expensive llm calls by pasting large amounts of text in the message box. This pr limits user messages to 6000 characters

### How can this be tested?
Go to the recommendation bot. Paste a long message (a wikipedia article that's longer than 6000 characters for example) in the message box. The bot should not break. From the shell run
```
from ai_chatbots.models import *
 DjangoCheckpoint.objects.last().__dict__
```
The last human message should be truncated to 6000 characters

Paste the long message into the tutorbot. The bot should not break .
```
 TutorBotOutput.objects.last().__dict__
```
should show the human message truncated to 6000 characters