### PR TITLE
change rc urls

### DIFF
--- a/env/frontend.env
+++ b/env/frontend.env
@@ -11,8 +11,8 @@ NEXT_PUBLIC_OPENEDX_API_BASE_URL="/openedx_proxy/"
 # Dev-only, Proxy to Deployed OpenEdx LMS
 # After logging in to the `NEXT_PUBLIC_OPENEDX_PROXY_TARGET` url, copy the value
 # of `OPENEDX_SESSION_COOKIE_NAME` cookie and set it to `OPENEDX_SESSION_COOKIE_VALUE`
-NEXT_PUBLIC_OPENEDX_PROXY_TARGET=https://courses-qa.mitxonline.mit.edu/
-NEXT_PUBLIC_OPENEDX_LOGIN_URL='https://courses-qa.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login'
+NEXT_PUBLIC_OPENEDX_PROXY_TARGET=https://courses-rc.mitxonline.mit.edu/
+NEXT_PUBLIC_OPENEDX_LOGIN_URL='https://courses-rc.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login'
 OPENEDX_SESSION_COOKIE_NAME=mitxonline-qa-edx-lms-sessionid
 # OPENEDX_SESSION_COOKIE_VALUE=set-this-in-frontend.local.env
 


### PR DESCRIPTION
### What are the relevant tickets?
none

### Description (What does it do?)
the mitxonline rc url is now https://courses-rc.mitxonline.mit.edu/. Change the default url in mit learn

### How can this be tested?
You should see "To use this feature, you must be logged in to OpenEdx. Please log in at https://rc.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login" at http://ai.open.odl.local:8003/?rec_prompt=&tab=AssessmentGPT&=. I was not able to use the cookie to access course content but I think that's due to ongoing issues with login on rc 