### PR TITLE
update open-learning-ai-tutor

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1973,13 +1973,13 @@ email = ["email-validator (>=2.1,<3.0)"]
 
 [[package]]
 name = "e2b"
-version = "1.5.2"
+version = "1.5.6"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "e2b-1.5.2-py3-none-any.whl", hash = "sha256:8cf755f2ff04098daa7ac778f768eee1df730a6181637fe124210345999890b3"},
-    {file = "e2b-1.5.2.tar.gz", hash = "sha256:29ed891ae04ffafff1744c57eff55901200f15030d34ac3fe76d6672e2bf7845"},
+    {file = "e2b-1.5.6-py3-none-any.whl", hash = "sha256:ca567af466bb370bef01cb2211ba231dbbe743137387c2a40cecf8819d6f9535"},
+    {file = "e2b-1.5.6.tar.gz", hash = "sha256:05da24b27d7a855edd374935c47a9e9faa9b4c3cc41a039a0ac3ee1cebedccf9"},
 ]
 
 [package.dependencies]
@@ -1993,18 +1993,18 @@ typing-extensions = ">=4.1.0"
 
 [[package]]
 name = "e2b-code-interpreter"
-version = "1.5.1"
+version = "1.5.2"
 description = "E2B Code Interpreter - Stateful code execution"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "e2b_code_interpreter-1.5.1-py3-none-any.whl", hash = "sha256:c8ee6f77bcb9c53422df336abbd37d5bf6318c3967b87444b39e3428a54c5e08"},
-    {file = "e2b_code_interpreter-1.5.1.tar.gz", hash = "sha256:e39485dd2ffb148a902e8c05c8f573feeb7ca87f8498f02a4db65630e76364e1"},
+    {file = "e2b_code_interpreter-1.5.2-py3-none-any.whl", hash = "sha256:5c3188d8f25226b28fef4b255447cc6a4c36afb748bdd5180b45be486d5169f3"},
+    {file = "e2b_code_interpreter-1.5.2.tar.gz", hash = "sha256:3bd6ea70596290e85aaf0a2f19f28bf37a5e73d13086f5e6a0080bb591c5a547"},
 ]
 
 [package.dependencies]
 attrs = ">=21.3.0"
-e2b = ">=1.4.0,<2.0.0"
+e2b = ">=1.5.4,<2.0.0"
 httpx = ">=0.20.0,<1.0.0"
 
 [[package]]
@@ -4793,13 +4793,13 @@ sympy = "*"
 
 [[package]]
 name = "open-learning-ai-tutor"
-version = "0.2.3"
+version = "0.2.4"
 description = "AI powered tutor"
 optional = false
 python-versions = "~=3.12"
 files = [
-    {file = "open_learning_ai_tutor-0.2.3-py3-none-any.whl", hash = "sha256:15a047d4d0fcac68f95654ff35589f5864824ea8ec4fae66dc84e28afe682f60"},
-    {file = "open_learning_ai_tutor-0.2.3.tar.gz", hash = "sha256:53c043f499f81a1819a2b8db0ea21eae3e17632e5eea60898733ca658b4dacf7"},
+    {file = "open_learning_ai_tutor-0.2.4-py3-none-any.whl", hash = "sha256:46cf2d3551c17a2db115abc228425c41a87e9f55d0094090494d400ed8c101ea"},
+    {file = "open_learning_ai_tutor-0.2.4.tar.gz", hash = "sha256:875755254154dd7f646bb7cb5c75ad9b6839721961c8bd4f618d99d45ded8eaf"},
 ]
 
 [package.dependencies]
@@ -8807,4 +8807,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.13.5"
-content-hash = "b6a989c4528005ade67b06e1f2446fc77ec560ca3a7280ddcd8cb2942e5d1556"
+content-hash = "1b24fc408a50c6ca76500e94ad38e60d2270e968e9f0c373b90af1d84462f382"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ ulid-py = "^1.0.0"
 uvicorn = {extras = ["standard"], version = "^0.34.0"}
 langmem = "^0.0.27"
 beautifulsoup4 = "^4.13.4"
-open-learning-ai-tutor = "^0.2.3"
+open-learning-ai-tutor = "^0.2.4"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7783

### Description (What does it do?)
Currently the prompt to generate the assessment of the student intent instructs the ai to only consider the latest message but the full assessment history is sent as part of the prompt. We can save money by only sending the latest message

### How can this be tested?
Tutor should work normally