### PR TITLE
Track AI costs in Posthog

### DIFF
--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -2,20 +2,23 @@
 
 import json
 import logging
-from typing import Any, cast
-from uuid import uuid4
+from typing import Any, Optional, cast
+from uuid import UUID, uuid4
 
+import litellm
 from django.conf import settings
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import (
     AIMessage,
     AnyMessage,
+    BaseMessage,
     HumanMessage,
     RemoveMessage,
     SystemMessage,
     ToolMessage,
 )
 from langchain_core.messages.utils import count_tokens_approximately
+from langchain_core.outputs import LLMResult
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate
 from langgraph.utils.runnable import RunnableCallable
@@ -28,6 +31,7 @@ from langmem.short_term.summarization import (
     TokenCounter,
 )
 from langsmith import Client as LangsmithClient
+from posthog.ai.langchain import CallbackHandler
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -440,3 +444,144 @@ def get_langsmith_prompt(prompt_name: str) -> str:
         else:
             log.warning("Prompt '%s' not found in LangSmith.", prompt_name)
     return None
+
+
+def format_posthog_messages(messages: list[BaseMessage]) -> list[dict]:
+    """
+    Standardize messages to dicts.
+    """
+    flattened_messages = []
+    for message_list in messages:
+        flattened_messages.extend(message_list)
+
+    # Convert LangChain messages to the format LiteLLM expects
+    return [{"role": msg.type, **msg.__dict__} for msg in flattened_messages]
+
+
+class TokenTrackingCallbackHandler(CallbackHandler):
+    """
+    PostHog callback handler that tracks token counts for cost
+    calculation using LiteLLM's token_counter
+    """
+
+    def __init__(self, model_name: str, **kwargs):
+        self.bot = kwargs.pop("bot", None)
+        super().__init__(**kwargs)
+        self.model_name = model_name
+        self.input_tokens = 0
+        self.set_trace_attributes()
+
+    def set_trace_attributes(self):
+        """Set trace attributes for PostHog"""
+        self._client.capture(
+            event="$ai_trace",
+            distinct_id=self.bot.user_id,
+            properties={
+                "$ai_trace_id": self.bot.thread_id,
+                "$ai_span_name": self.bot.JOB_ID,
+                "botName": self.bot.JOB_ID,
+            },
+        )
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ):
+        """Format messages and estimate input tokens"""
+        posthog_messages = format_posthog_messages(messages)
+        try:
+            # Use LiteLLM token_counter with the proper format
+            self.input_tokens = litellm.token_counter(
+                model=self.model_name, messages=posthog_messages
+            )
+        except Exception:
+            # Fallback to character-based estimation
+            total_input_chars = 0
+            for message_list in messages:
+                for message in message_list:
+                    if hasattr(message, "content"):
+                        total_input_chars += len(str(message.content))
+                    else:
+                        total_input_chars += len(str(message))
+            self.input_tokens = total_input_chars // 4
+            log.exception("LiteLLM token_counter failed, using character estimation")
+        if not hasattr(self, "_properties") or self._properties is None:
+            self._properties = {}
+        self._properties.update(
+            {
+                "question": (
+                    [
+                        msg["content"]
+                        for msg in posthog_messages
+                        if msg["type"] == "human"
+                    ]
+                    or [""]
+                )[-1],
+                "$ai_input": posthog_messages,
+            }
+        )
+
+        # Call parent method
+        super().on_chat_model_start(
+            serialized, messages, run_id=run_id, parent_run_id=parent_run_id, **kwargs
+        )
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ):
+        # Calculate output tokens using LiteLLM's token_counter
+        output_tokens = 0
+
+        try:
+            # Collect all output text
+            output_text = (
+                "".join(
+                    [
+                        gen_chunk.text
+                        for generation in response.generations
+                        for gen_chunk in generation
+                        if hasattr(gen_chunk, "text") and gen_chunk.text
+                    ]
+                )
+                if hasattr(response, "generations") and response.generations
+                else ""
+            )
+
+            # Use LiteLLM token_counter for the complete output text
+            if output_text:
+                output_tokens = litellm.token_counter(
+                    model=self.model_name, text=output_text
+                )
+        except Exception:
+            # Fallback to character-based estimation
+            if hasattr(response, "generations") and response.generations:
+                for generation in response.generations:
+                    for gen_chunk in generation:
+                        if hasattr(gen_chunk, "text") and gen_chunk.text:
+                            output_tokens += len(gen_chunk.text) // 4
+            log.exception(
+                "token_counter failed, using character estimation for tokens."
+            )
+        self._properties.update(
+            {
+                "answer": output_text,
+                "$ai_input_tokens": self.input_tokens,
+                "$ai_output_tokens": output_tokens,
+                "$ai_trace_name": self.bot.JOB_ID,
+                "$ai_span_name": self.bot.JOB_ID,
+            }
+        )
+        # Call parent method
+        super().on_llm_end(
+            response, run_id=run_id, parent_run_id=parent_run_id, **kwargs
+        )

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -199,8 +199,6 @@ async def test_get_completion(
     posthog_settings, mocker, mock_checkpointer, debug, search_results
 ):
     """Test that the ResourceRecommendationBot get_completion method returns expected values."""
-    posthog_settings.AI_DEBUG = debug
-    mock_posthog = mocker.patch("ai_chatbots.chatbots.posthog", autospec=True)
     mocker.patch(
         "ai_chatbots.chatbots.CompiledGraph.aget_state_history",
         return_value=MockAsyncIterator(
@@ -252,16 +250,6 @@ async def test_get_completion(
     if debug:
         assert '<!-- {"metadata"' in results
     assert "".join([value.decode() for value in expected_return_value]) in results
-    mock_posthog.Posthog.return_value.capture.assert_called_once_with(
-        "anonymous",
-        event="RECOMMENDATION_JOB",
-        properties={
-            "question": user_msg,
-            "answer": ANY,
-            "metadata": "{}",
-            "user": "anonymous",
-        },
-    )
 
 
 async def test_recommendation_bot_create_agent_graph(mocker, mock_checkpointer):
@@ -586,8 +574,6 @@ async def test_tutor_get_completion(
     posthog_settings, mocker, mock_checkpointer, variant
 ):
     """Test that the tutor bot get_completion method returns expected values."""
-    mock_posthog = mocker.patch("ai_chatbots.chatbots.posthog", autospec=True)
-
     final_message = [
         "values",
         {
@@ -701,28 +687,6 @@ async def test_tutor_get_completion(
         new_history, intents, assessment_history, metadata
     )
     assert history.edx_module_id == (edx_module_id or "")
-
-    mock_posthog.Posthog.return_value.capture.assert_called_once_with(
-        "anonymous",
-        event="TUTOR_JOB",
-        properties={
-            "question": user_msg,
-            "answer": results,
-            "metadata": json.dumps(
-                {
-                    "edx_module_id": edx_module_id,
-                    "block_siblings": block_siblings,
-                    "problem": "problem_xml" if variant == "edx" else "",
-                    "problem_set": "problem_set_xml"
-                    if variant == "edx"
-                    else "problem_set",
-                    "problem_set_title": problem_set_title,
-                    "run_readable_id": run_readable_id,
-                }
-            ),
-            "user": "anonymous",
-        },
-    )
 
 
 async def test_video_gpt_bot_create_agent_graph(mocker, mock_checkpointer):


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7957

### Description (What does it do?)
Refactors how chatbot calls are sent to Posthog, so that their costs can be calculated.

https://posthog.com/docs/ai-engineering/observability

### Screenshots (if appropriate):

#### Traces (Chat sessions)
<img width="1567" height="499" alt="Screenshot 2025-08-03 191005" src="https://github.com/user-attachments/assets/68f0eaa5-fce5-4b23-853d-8049369e003b" />

#### Generations (LLM calls)
<img width="1593" height="1090" alt="Screenshot 2025-08-03 191033" src="https://github.com/user-attachments/assets/a4e5f4fa-6074-45cb-a969-8bcfe84b8a84" />

### How can this be tested?
- Set the following env variables, using RC values:
```
POSTHOG_API_HOST=https://app.posthog.com
POSTHOG_PERSONAL_API_KEY=<secret>
POSTHOG_PROJECT_API_KEY=<secret>
POSTHOG_PROJECT_ID=<id>
POSTHOG_ENABLED=True
```
- Restart containers
- Use a few of the chatbots, including the tutorbot and at least 1 other.
- Log into Posthog, go to "Activities".  Make another column visible ("botName") and then filter event by "AI Trace (LLM)".  You should see a row for every chat session.
- Go to "LLM observability".  Then click on the "Traces" tab (chat sessions) and "Generations" tab (messages).  Each row should show a cost.

### Additional Context

In order for data to show in "LLM Observability", the "event" value had to be changed from the bot name (like "SYLLABUS_BOT") to values like "$ai_trace", "$ai_span", "$ai_generation".  So I added a new "botName" property for generations, and assigned the same value to trace name for traces.  Any current posthog reports/filters that currently rely on "event" for filtering LLM calls should be changed to "botName", which can be added as a column in the Posthog UI.




