### PR TITLE
canvas tutorbot

### DIFF
--- a/ai_chatbots/routing.py
+++ b/ai_chatbots/routing.py
@@ -38,4 +38,9 @@ http_patterns = [
         consumers.TutorBotHttpConsumer.as_asgi(),
         name="tutor_agent_sse",
     ),
+    re_path(
+        r"http/canvas_tutor_agent/",
+        consumers.CanvasTutorBotHttpConsumer.as_asgi(),
+        name="canvas_tutor_agent_sse",
+    ),
 ]

--- a/ai_chatbots/serializers.py
+++ b/ai_chatbots/serializers.py
@@ -146,6 +146,19 @@ class TutorChatRequestSerializer(ChatRequestSerializer):
     )
 
 
+class CanvasTutorChatRequestSerializer(ChatRequestSerializer):
+    """
+    Serializer for requests sent to the tutor chatbot.
+    """
+
+    problem_set_title = serializers.CharField(required=True, allow_blank=False)
+    run_readable_id = serializers.CharField(required=True, allow_blank=False)
+    object_id_field = serializers.SerializerMethodField()
+
+    def get_object_id_field(self, obj):
+        return f"{obj.get('run_readable_id', '')} - {obj.get('problem_set_title', '')}"
+
+
 class LLMModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = LLMModel

--- a/ai_chatbots/urls.py
+++ b/ai_chatbots/urls.py
@@ -27,6 +27,11 @@ v0_urls = [
         views.GetTranscriptBlockId.as_view(),
         name="get_transcript_edx_module_id",
     ),
+    path(
+        r"problem_set_list/",
+        views.ProblemSetList.as_view(),
+        name="problem_set_list",
+    ),
 ]
 
 urlpatterns = [

--- a/frontend-demo/api/src/generated/v0/api.ts
+++ b/frontend-demo/api/src/generated/v0/api.ts
@@ -1977,6 +1977,172 @@ export class LlmModelsApi extends BaseAPI {
 }
 
 /**
+ * ProblemSetListApi - axios parameter creator
+ * @export
+ */
+export const ProblemSetListApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * API view to get a list of problem sets for a given course.
+     * @param {string} run_readable_id run_readable_id of the course run
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    problemSetListRetrieve: async (
+      run_readable_id: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'run_readable_id' is not null or undefined
+      assertParamExists(
+        "problemSetListRetrieve",
+        "run_readable_id",
+        run_readable_id,
+      )
+      const localVarPath = `/api/v0/problem_set_list/`.replace(
+        `{${"run_readable_id"}}`,
+        encodeURIComponent(String(run_readable_id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * ProblemSetListApi - functional programming interface
+ * @export
+ */
+export const ProblemSetListApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    ProblemSetListApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * API view to get a list of problem sets for a given course.
+     * @param {string} run_readable_id run_readable_id of the course run
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async problemSetListRetrieve(
+      run_readable_id: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.problemSetListRetrieve(
+          run_readable_id,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["ProblemSetListApi.problemSetListRetrieve"]?.[index]
+          ?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * ProblemSetListApi - factory interface
+ * @export
+ */
+export const ProblemSetListApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = ProblemSetListApiFp(configuration)
+  return {
+    /**
+     * API view to get a list of problem sets for a given course.
+     * @param {ProblemSetListApiProblemSetListRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    problemSetListRetrieve(
+      requestParameters: ProblemSetListApiProblemSetListRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .problemSetListRetrieve(requestParameters.run_readable_id, options)
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for problemSetListRetrieve operation in ProblemSetListApi.
+ * @export
+ * @interface ProblemSetListApiProblemSetListRetrieveRequest
+ */
+export interface ProblemSetListApiProblemSetListRetrieveRequest {
+  /**
+   * run_readable_id of the course run
+   * @type {string}
+   * @memberof ProblemSetListApiProblemSetListRetrieve
+   */
+  readonly run_readable_id: string
+}
+
+/**
+ * ProblemSetListApi - object-oriented interface
+ * @export
+ * @class ProblemSetListApi
+ * @extends {BaseAPI}
+ */
+export class ProblemSetListApi extends BaseAPI {
+  /**
+   * API view to get a list of problem sets for a given course.
+   * @param {ProblemSetListApiProblemSetListRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ProblemSetListApi
+   */
+  public problemSetListRetrieve(
+    requestParameters: ProblemSetListApiProblemSetListRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return ProblemSetListApiFp(this.configuration)
+      .problemSetListRetrieve(requestParameters.run_readable_id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
  * PromptsApi - axios parameter creator
  * @export
  */

--- a/frontend-demo/src/app/(home)/CanvasAssessmentContent.tsx
+++ b/frontend-demo/src/app/(home)/CanvasAssessmentContent.tsx
@@ -1,0 +1,193 @@
+import { CANVAS_ASSESSMENT_GPT_URL } from "@/services/ai/urls"
+import { type AiChatProps } from "@mitodl/smoot-design/ai"
+import { useSearchParamSettings } from "./util"
+import { MathJaxContext } from "better-react-mathjax"
+import AiChatDisplay from "./StyledAiChatDisplay"
+import BaseChatContent from "./BaseChatContent"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo, useEffect } from "react"
+import React from "react"
+import TextField from "@mui/material/TextField"
+import { useFormik } from "formik"
+import MenuItem from "@mui/material/MenuItem"
+import Button from "@mui/material/Button"
+
+const CONVERSATION_STARTERS: AiChatProps["conversationStarters"] = []
+const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
+  { role: "assistant", content: "Hi, do you need any help?" },
+]
+const DEFAULT_COURSE_RUN = "14566-kaleba:20211202+canvas"
+type CanvasProblemSelectionFormProps = {
+  defaultRun: string
+  problemSetList: string[] | []
+  onChange: (values: { run: string; problem_set_title: string }) => void
+}
+
+const CanvasProblemSelectionForm: React.FC<CanvasProblemSelectionFormProps> = ({
+  defaultRun,
+  problemSetList,
+  onChange,
+}) => {
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      run: defaultRun,
+      problem_set_title:
+        problemSetList && problemSetList.length > 0 ? problemSetList[0] : "",
+    },
+    onSubmit: (values) => {
+      onChange({
+        run: values.run,
+        problem_set_title: "",
+      })
+    },
+    validateOnChange: false,
+  })
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <TextField
+        size="small"
+        label="Course Run Readable ID"
+        fullWidth
+        autoCapitalize="off"
+        spellCheck={false}
+        margin="normal"
+        name="run"
+        value={formik.values.run}
+        onChange={formik.handleChange}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        sx={{ mt: 1, mb: 2 }}
+      >
+        Update Course Run
+      </Button>
+      <TextField
+        label="Problem Set"
+        size="small"
+        margin="normal"
+        name="problem_set_title"
+        fullWidth
+        select
+        onChange={(e) => {
+          formik.handleChange(e)
+          // Call onChange with updated values so parent can update settings and trigger useQuery
+          onChange({
+            problem_set_title: e.target.value,
+            run: formik.values.run,
+          })
+        }}
+        value={formik.values.problem_set_title}
+      >
+        {problemSetList.map((problemSet) => (
+          <MenuItem key={problemSet} value={problemSet}>
+            {problemSet}
+          </MenuItem>
+        ))}
+      </TextField>
+    </form>
+  )
+}
+
+const CanvasAssessmentContent = () => {
+  const [settings, setSettings] = useSearchParamSettings({
+    tutor_model: "",
+    run: DEFAULT_COURSE_RUN,
+    problem_set_title: "",
+    tutor_prompt: "",
+  })
+
+  const getProblemSetList = async (runReadableId: string) => {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_MITOL_API_BASE_URL}/api/v0/problem_set_list/?run_readable_id=${encodeURIComponent(runReadableId)}`,
+    )
+    return response.json()
+  }
+
+  const problemSetListResult = useQuery({
+    queryKey: ["problemSetList", settings.run],
+    queryFn: () => getProblemSetList(settings.run),
+    enabled: !!settings.run,
+  })
+
+  const { problemSetList: problemSetList } = useMemo(() => {
+    if (problemSetListResult.isLoading) return { problemSetList: [] }
+    if (problemSetListResult.data.error) {
+      return { problemSetList: [] }
+    }
+
+    return {
+      problemSetList: problemSetListResult.data.problem_set_titles,
+      error: null,
+    }
+  }, [problemSetListResult, settings.run])
+
+  useEffect(() => {
+    // Set problem_set_title to first item or "" whenever problemSetList changes
+    if (problemSetList && problemSetList.length > 0) {
+      if (settings.problem_set_title !== problemSetList[0]) {
+        setSettings({
+          problem_set_title: problemSetList[0],
+        })
+      }
+    } else if (settings.problem_set_title !== "") {
+      setSettings({
+        problem_set_title: "",
+      })
+    }
+  }, [problemSetList])
+
+  const isReady = !!problemSetList
+
+  return (
+    <BaseChatContent
+      title="CanvasAssessmentGPT"
+      apiUrl={CANVAS_ASSESSMENT_GPT_URL}
+      chatIdPrefix="canvas-assessment-gpt"
+      conversationStarters={CONVERSATION_STARTERS}
+      initialMessages={INITIAL_MESSAGES}
+      promptQueryKey=""
+      promptSettingKey=""
+      modelSettingKey="tutor_model"
+      isReady={isReady}
+      extraBody={{
+        model: settings.tutor_model,
+        run_readable_id: settings.run,
+        problem_set_title: settings.problem_set_title,
+      }}
+      settings={settings}
+      setSettings={setSettings}
+      showSystemPrompt={false}
+      sidebarContent={
+        <>
+          <CanvasProblemSelectionForm
+            defaultRun={settings.run}
+            problemSetList={problemSetList || []}
+            onChange={(values) => {
+              setSettings({
+                problem_set_title: values.problem_set_title,
+                run: values.run,
+              })
+            }}
+          />
+        </>
+      }
+      chatDisplayProps={{
+        useMathJax: true,
+      }}
+    >
+      <MathJaxContext>
+        <AiChatDisplay
+          entryScreenEnabled={false}
+          conversationStarters={CONVERSATION_STARTERS}
+          useMathJax={true}
+        />
+      </MathJaxContext>
+    </BaseChatContent>
+  )
+}
+
+export default CanvasAssessmentContent

--- a/frontend-demo/src/app/(home)/ChatTabs.tsx
+++ b/frontend-demo/src/app/(home)/ChatTabs.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from "next/navigation"
 import RecommendationContent from "./RecommendationContent"
 import SyllabusContent from "./SyllabusContent"
 import AssessmentContent from "./AssessmentContent"
+import CanvasAssessmentContent from "./CanvasAssessmentContent"
 import VideoContent from "./VideoContent"
 import { useEffect, useState } from "react"
 
@@ -15,6 +16,7 @@ export enum ChatTab {
   SyllabusGPT = "SyllabusGPT",
   VideoGPT = "VideoGPT",
   AssessmentGPT = "AssessmentGPT",
+  CanvasAssessmentGPT = "CanvasAssessmentGPT",
 }
 
 const ChatTabs = () => {
@@ -43,6 +45,10 @@ const ChatTabs = () => {
           <Tab label="SyllabusGPT" value={ChatTab.SyllabusGPT} />
           <Tab label="VideoGPT" value={ChatTab.VideoGPT} />
           <Tab label="AssessmentGPT" value={ChatTab.AssessmentGPT} />
+          <Tab
+            label="CanvasAssessmentGPT"
+            value={ChatTab.CanvasAssessmentGPT}
+          />
         </TabList>
       </Box>
       <TabPanel value={ChatTab.RecommendationGPT}>
@@ -56,6 +62,9 @@ const ChatTabs = () => {
       </TabPanel>
       <TabPanel value={ChatTab.AssessmentGPT}>
         <AssessmentContent />
+      </TabPanel>
+      <TabPanel value={ChatTab.CanvasAssessmentGPT}>
+        <CanvasAssessmentContent />
       </TabPanel>
     </TabContext>
   )

--- a/frontend-demo/src/services/ai/urls.ts
+++ b/frontend-demo/src/services/ai/urls.ts
@@ -4,10 +4,11 @@ const RECOMMENDATION_GPT_URL = `${BASE_URL}/http/recommendation_agent/`
 const SYLLABUS_GPT_URL = `${BASE_URL}/http/syllabus_agent/`
 const VIDEO_GPT_URL = `${BASE_URL}/http/video_gpt_agent/`
 const ASSESSMENT_GPT_URL = `${BASE_URL}/http/tutor_agent/`
-
+const CANVAS_ASSESSMENT_GPT_URL = `${BASE_URL}/http/canvas_tutor_agent/`
 export {
   RECOMMENDATION_GPT_URL,
   SYLLABUS_GPT_URL,
   VIDEO_GPT_URL,
   ASSESSMENT_GPT_URL,
+  CANVAS_ASSESSMENT_GPT_URL,
 }

--- a/main/settings.py
+++ b/main/settings.py
@@ -654,6 +654,10 @@ AI_MIT_CONTENTFILE_URL = get_string(
     name="AI_MIT_CONTENTFILE_URL",
     default="https://api.learn.mit.edu/api/v1/contentfiles/",
 )
+PROBLEM_SET_URL = get_string(
+    name="PROBLEM_SET_URL",
+    default="https://api.learn.mit.edu/api/v0/tutor/problems/",
+)
 LEARN_ACCESS_TOKEN = get_string(
     name="LEARN_ACCESS_TOKEN",
     default="",

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -228,6 +228,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/LLMModel'
           description: ''
+  /api/v0/problem_set_list/:
+    get:
+      operationId: problem_set_list_retrieve
+      description: API view to get a list of problem sets for a given course.
+      parameters:
+      - in: path
+        name: run_readable_id
+        schema:
+          type: string
+        description: run_readable_id of the course run
+        required: true
+      tags:
+      - problem_set_list
+      security:
+      - {}
+      responses:
+        '200':
+          description: List of problem sets
+        '500':
+          description: Error retrieving problem sets
   /api/v0/prompts/:
     get:
       operationId: prompts_list

--- a/poetry.lock
+++ b/poetry.lock
@@ -1972,13 +1972,13 @@ email = ["email-validator (>=2.1,<3.0)"]
 
 [[package]]
 name = "e2b"
-version = "1.5.6"
+version = "1.11.0"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "e2b-1.5.6-py3-none-any.whl", hash = "sha256:ca567af466bb370bef01cb2211ba231dbbe743137387c2a40cecf8819d6f9535"},
-    {file = "e2b-1.5.6.tar.gz", hash = "sha256:05da24b27d7a855edd374935c47a9e9faa9b4c3cc41a039a0ac3ee1cebedccf9"},
+    {file = "e2b-1.11.0-py3-none-any.whl", hash = "sha256:3027dd2e9aed1b90e4475c879238bd8a19cf1dc6fd5f042c5dc1a06027cd3b35"},
+    {file = "e2b-1.11.0.tar.gz", hash = "sha256:40023cf0d569d49b5d9688a21f84d41bbbf57fbb49984dcb74490f41ab5a5c6d"},
 ]
 
 [package.dependencies]
@@ -4792,13 +4792,13 @@ sympy = "*"
 
 [[package]]
 name = "open-learning-ai-tutor"
-version = "0.2.5"
+version = "0.2.6"
 description = "AI powered tutor"
 optional = false
 python-versions = "~=3.12"
 files = [
-    {file = "open_learning_ai_tutor-0.2.5-py3-none-any.whl", hash = "sha256:4350ffd8d17fa656ae78b121aa1085f930460743d6d065540a583bf9440944e3"},
-    {file = "open_learning_ai_tutor-0.2.5.tar.gz", hash = "sha256:9df13921f4de66a5bd25b5530c6c8e390f0cd6fbb50c6f9f0597f35698243eb3"},
+    {file = "open_learning_ai_tutor-0.2.6-py3-none-any.whl", hash = "sha256:2942281d0344a77a5e3ef4ae92bffa5ad13965e9e6f588bc247860b0b1b3ee53"},
+    {file = "open_learning_ai_tutor-0.2.6.tar.gz", hash = "sha256:80c78bc358eebf9417a132262a302b9444e572afafd6059fa3aa9626b392b4c9"},
 ]
 
 [package.dependencies]
@@ -8806,4 +8806,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.13.5"
-content-hash = "d6b2efef813aa29d150e4a4c70246fca65d5465fdb24a15b98aeba3b9e309e94"
+content-hash = "2457dab6bd8bd6689784653cf5c93441cf5a2a6214c53f32887cc2062dc984a4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ ulid-py = "^1.0.0"
 uvicorn = {extras = ["standard"], version = "^0.34.0"}
 langmem = "^0.0.27"
 beautifulsoup4 = "^4.13.4"
-open-learning-ai-tutor = "^0.2.5"
+open-learning-ai-tutor = "^0.2.6"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7944


### Description (What does it do?)
This pr creates a canvas version of the Tutorbot UI

### Screenshots (if appropriate):
<img width="1724" height="906" alt="Screenshot 2025-08-01 at 11 26 39 AM" src="https://github.com/user-attachments/assets/df5df7be-b706-4cdf-8187-f683931c6930" />


### How can this be tested?
Go to http://ai.open.odl.local:8003/?rec_prompt=&tab=CanvasAssessmentGPT

You should be able to update the course run. Currently 14566-kaleba:20211202+canvas is the only course run with problem files. If you change it to something else the problem selection dropdown will be empty. If you select 14566-kaleba:20211202+canvas again after selecting something else the problem dropdown will be repopulated.

You should be able to select a problem set from the dropdown.

You should  be able to chat with the tutor about the problem set. If you check your networks tab in developer tools you should see a request to /canvas_tutor_agent/ with the correct problem_set_title and run_readable_id in the params

### Additional Context
depends on https://github.com/mitodl/open-learning-ai-tutor/pull/37


Currently there isn't any authentication on the canvas tutor endpoint, since i wasn't sure how to make that work with the current learn-ai demo ui, that will be a followup pr

Updating the Tutor graph to ask for which problem in the problem set the user wants to work on is also going to be a follow up pr
