### PR TITLE
Add gpt-5, 5-mini to the list of models that do not like the temperature variable

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -708,7 +708,8 @@ AI_BUDGET_DURATION = get_string(name="AI_BUDGET_DURATION", default="60m")
 AI_MAX_BUDGET = get_float(name="AI_MAX_BUDGET", default=0.05)
 AI_ANON_LIMIT_MULTIPLIER = get_float(name="AI_ANON_LIMIT_MULTIPLIER", default=10.0)
 AI_UNSUPPORTED_TEMP_MODELS = get_list_of_str(
-    name="AI_UNSUPPORTED_TEMP_MODELS", default=["openai/o3-mini"]
+    name="AI_UNSUPPORTED_TEMP_MODELS",
+    default=["openai/o3-mini", "openai/gpt-5", "openai/gpt-5-mini"],
 )
 AI_PROMPT_CACHE_FUNCTION = get_string(
     name="AI_PROMPT_CACHE_FUNCTION", default="ai_chatbots.utils.get_django_cache"


### PR DESCRIPTION

### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds gpt-5 and gpt-5-mini to the list of models that do not like temperature values

### How can this be tested?
- Use the same `OPENAI_API_KEY` value as RC
- Add `openai/gpt-5` and `openai/gpt-5-mini` to the list of available LLM models at http://ai.open.odl.local:8005/admin/ai_chatbots/llmmodel/
- Choose the new models when making chatbot requests, you should not get this exception:

> litellm.BadRequestError: OpenAIException - Unsupported value: 'temperature' does not support 0.1 with this model.

You might get an exception about having to verify your organization, depending on how long it takes to do so (under way).

