### PR TITLE
add token authentication to canvas tutor endpoint

### DIFF
--- a/ai_chatbots/consumers.py
+++ b/ai_chatbots/consumers.py
@@ -535,7 +535,7 @@ class TutorBotHttpConsumer(BaseBotHttpConsumer):
 
 class CanvasTutorBotHttpConsumer(BaseBotHttpConsumer):
     """
-    Async HTTP consumer for the tutor bot.
+    Async HTTP consumer for the canvas tutor bot.
     """
 
     serializer_class = CanvasTutorChatRequestSerializer
@@ -584,6 +584,28 @@ class CanvasTutorBotHttpConsumer(BaseBotHttpConsumer):
             agent=self.ROOM_NAME,
             object_id=serializer.validated_data.get("object_id_field"),
         )
+
+
+class DemoCanvasTutorBotHttpConsumer(CanvasTutorBotHttpConsumer):
+    """
+    Async HTTP consumer for the tutor bot. This is a demo version that
+    does not require authentication but is limited to demo runs.
+    """
+
+    def create_chatbot(
+        self,
+        serializer: CanvasTutorChatRequestSerializer,
+        checkpointer: BaseCheckpointSaver,
+    ):
+        """Return a TutorBot instance"""
+        run_readable_id = serializer.validated_data.get("run_readable_id", None)
+
+        if run_readable_id not in settings.CANVAS_TUTOR_DEMO_RUN_READABLE_IDS:
+            error = f"Invalid run_readable_id: {run_readable_id}. "
+            raise ValidationError(error)
+
+        else:
+            return super().create_chatbot(serializer, checkpointer)
 
 
 class VideoGPTBotHttpConsumer(BaseBotHttpConsumer):

--- a/ai_chatbots/routing.py
+++ b/ai_chatbots/routing.py
@@ -43,4 +43,9 @@ http_patterns = [
         consumers.CanvasTutorBotHttpConsumer.as_asgi(),
         name="canvas_tutor_agent_sse",
     ),
+    re_path(
+        r"http/demo_canvas_tutor_agent/",
+        consumers.DemoCanvasTutorBotHttpConsumer.as_asgi(),
+        name="demo_canvas_tutor_agent_sse",
+    ),
 ]

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -25,6 +25,25 @@ routes:
         allow_headers: "**"
         allow_credential: true
   - id: 2
+    name: "canvas_tutor_agent"
+    desc: "Protected route for canvas tutor agent - requires canvas_token header"
+    priority: 20
+    upstream_id: 1
+    uri: "/http/canvas_tutor_agent/"
+    plugins:
+      key-auth:
+        header: "canvas_token"
+        _meta:
+          disable: false
+      consumer-restriction:
+        whitelist:
+          - "canvas_agent"
+      cors:
+        allow_origins: "**"
+        allow_methods: "**"
+        allow_headers: "**"
+        allow_credential: true
+  - id: 3
     name: "passauth"
     desc: "Wildcard route that can use auth but doesn't require it."
     priority: 0
@@ -54,7 +73,7 @@ routes:
           set:
             Referrer-Policy: "origin"
     uri: "*"
-  - id: 3
+  - id: 4
     name: "logout-redirect"
     desc: "Strip trailing slash from logout redirect."
     priority: 10
@@ -63,7 +82,7 @@ routes:
     plugins:
       redirect:
         uri: "/logout"
-  - id: 4
+  - id: 5
     name: "reqauth"
     desc: "Routes that require authentication."
     priority: 10

--- a/env/backend.env
+++ b/env/backend.env
@@ -48,3 +48,4 @@ KEYCLOAK_SCOPES="openid profile ol-profile"
 # Channels settings
 REDIS_DOMAIN=redis://redis:6379/0
 AI_PROMPT_CACHE_FUNCTION=ai_chatbots.utils.get_django_cache
+CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas"]

--- a/frontend-demo/src/services/ai/urls.ts
+++ b/frontend-demo/src/services/ai/urls.ts
@@ -4,7 +4,7 @@ const RECOMMENDATION_GPT_URL = `${BASE_URL}/http/recommendation_agent/`
 const SYLLABUS_GPT_URL = `${BASE_URL}/http/syllabus_agent/`
 const VIDEO_GPT_URL = `${BASE_URL}/http/video_gpt_agent/`
 const ASSESSMENT_GPT_URL = `${BASE_URL}/http/tutor_agent/`
-const CANVAS_ASSESSMENT_GPT_URL = `${BASE_URL}/http/canvas_tutor_agent/`
+const CANVAS_ASSESSMENT_GPT_URL = `${BASE_URL}/http/demo_canvas_tutor_agent/`
 export {
   RECOMMENDATION_GPT_URL,
   SYLLABUS_GPT_URL,

--- a/main/settings.py
+++ b/main/settings.py
@@ -744,3 +744,8 @@ CONSUMER_THROTTLE_CLASSES = get_list_of_str(
     "CONSUMER_THROTTLE_CLASSES",
     ["main.consumer_throttles.UserScopedRateThrottle"],
 )
+
+CANVAS_TUTOR_DEMO_RUN_READABLE_IDS = get_list_of_str(
+    "CANVAS_TUTOR_DEMO_RUN_READABLE_IDS",
+    [],
+)


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/8055

### Description (What does it do?)
This pr adds token authentication to the canvas_tutor_agent endpoint. It also adds a demo_canvas_tutor_agent ui that does not require auth but is limited to demo courses

### How can this be tested?
go to http://ai.open.odl.local:8003/?rec_prompt=&tab=CanvasAssessmentGPT. The tutor should work for the demo course

```
curl -X POST http://ai.open.odl.local:8005/http/demo_canvas_tutor_agent/ \
    -H "Content-Type: application/json" \
    -d '{"message": "What do i do first", "run_readable_id": "14566-kaleba:20211202+canvas", "problem_set_title": "Problem Set 1"}'`
```
should return a tutor  response 

 ```
curl -X POST http://ai.open.odl.local:8005/http/demo_canvas_tutor_agent/ \
    -H "Content-Type: application/json" \
    -d '{"message": "What do i do first", "run_readable_id": "not_allowed", "problem_set_title": "Problem Set 1"}'`
should return
```
```
{"error": {"message": "[ErrorDetail(string='Invalid run_readable_id: not_allowed. ', code='invalid')]"}}%
```

```
  curl -X POST http://ai.open.odl.local:8005/http/canvas_tutor_agent/ \
    -H "Content-Type: application/json" \
    -H "canvas_token: 3f8a7c2e1b9d4e5f6a0b7c8d9e2f1a3b" \
    -d '{"message": "What do i do first", "run_readable_id": "14566-kaleba:20211202+canvas", "problem_set_title": "Problem Set 1"}'
```
should return a tutor response

```
 curl -X POST http://ai.open.odl.local:8005/http/canvas_tutor_agent/ \
    -H "Content-Type: application/json" \
    -d '{"message": "What do i do first", "run_readable_id": "14566-kaleba:20211202+canvas", "problem_set_title": "Problem Set 1"}'
```
should return
```
{"message":"Missing API key in request"}
``
