### PR TITLE
Better citations

### DIFF
--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -343,9 +343,15 @@ async def test_syllabus_bot_tool(
     expected_results = {
         "results": [
             {
-                "citation_title": resource.get("title")
-                or resource.get("content_title"),
-                "citation_url": resource.get("url"),
+                **(
+                    {
+                        "citation_title": resource.get("title")
+                        or resource.get("content_title"),
+                        "citation_url": resource.get("url"),
+                    }
+                    if resource.get("url")
+                    else {}
+                ),
                 **{key: resource.get(key) for key in retained_attributes},
             }
             for resource in raw_results

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -51,23 +51,36 @@ needed. Then perform a relevant search and send back the best results.
 """
 
 PROMPT_CITATIONS = """
-🚨 CITATION REQUIREMENTS 🚨
+======================================================================
+🚨 CRITICAL CITATION REQUIREMENTS — FOLLOW EXACTLY 🚨
+======================================================================
 
-For every paragraph and bullet point in your answer,
-check if the relevant search results for that paragraph have a `citation_url` value.
-If no, YOU MUST NOT add a citation.
-If yes, YOU MUST add citations to the paragraph in the correct format, described below.
+STEP 1: CHECK FOR citation_url IN EACH SEARCH RESULT
+- Only cite information that has a "citation_url" field in the tool results
+- If no citation_url exists for a piece of information, DO NOT cite it
 
-CITATION FORMAT - FOLLOW EXACTLY:
-- CORRECT FORMAT is [^🔗^](url) where url == search_result.citation_url
-- This is the ONLY acceptable hyperlink format
-- DO NOT ADD ANY CITATION URL THAT IS NOT PRESENT IN SEARCH RESULTS!
+STEP 2: USE EXACT CITATION FORMAT
+- Format: [^🔗^](<url>)
+- Replace <url> with the EXACT citation_url from the search result
+- Example: if search result citation_url value is "http://ocw.mit.edu", then
+  citation format should be [^🔗^](http://ocw.mit.edu)
 
-VERIFICATION CHECKLIST:
-- Does every citation use ONLY `[^🔗^](url)` where url == search_result.citation_url?
-  (If no, REMOVE IT!)
-- Are you using ANY other format? (If yes, FIX IT!)
-- Does the citation url appear in the search results? (If no, REMOVE IT!)
+STEP 3: VERIFY BEFORE RESPONDING
+Before you submit your answer, verify EVERY citation:
+- ✅ Does this URL appear in the tool search results?
+- ✅ Is it formatted as [^🔗^](<url>)?
+- ❌ NEVER make up, guess, or modify URLs
+- ❌ NEVER use any other citation format
+
+FORBIDDEN ACTIONS:
+- Creating fake URLs
+- Using "here" or other link text
+- Numbered citations like [1] or (1)
+- Plain URLs without the [^🔗^] format
+- Citing information without a citation_url
+
+REMEMBER: It's better to have NO citation than a WRONG citation.
+======================================================================
 """
 
 PROMPT_SYLLABUS = """You are an assistant named Tim, helping users answer questions

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -64,17 +64,19 @@ STEP 2: USE EXACT CITATION FORMAT
 - Replace <url> with the EXACT citation_url from the search result
 - Example: if search result citation_url value is "http://ocw.mit.edu", then
   citation format should be [^🔗^](http://ocw.mit.edu)
+- Example: if there is no citation_url value, DO NOT ADD A CITATION!
 
 STEP 3: VERIFY BEFORE RESPONDING
 Before you submit your answer, verify EVERY citation:
 - ✅ Does this URL appear in the tool search results?
 - ✅ Is it formatted as [^🔗^](<url>)?
-- ❌ NEVER make up, guess, or modify URLs
+- ❌ CRITICAL: NEVER make up, guess, or modify URLs
 - ❌ NEVER use any other citation format
+- ❌ NEVER use any hyperlink text except ^🔗^
 
 FORBIDDEN ACTIONS:
 - Creating fake URLs
-- Using "here" or other link text
+- Using "here", "syllabus", "assignmennts" or other hyperlink text
 - Numbered citations like [1] or (1)
 - Plain URLs without the [^🔗^] format
 - Citing information without a citation_url

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -52,15 +52,18 @@ needed. Then perform a relevant search and send back the best results.
 
 PROMPT_CITATIONS = """
 ======================================================================
-🚨 CRITICAL CITATION REQUIREMENTS — FOLLOW EXACTLY 🚨
+🚨 CRITICAL CITATIONS REQUIREMENTS — FOLLOW EXACTLY 🚨
 ======================================================================
 
+YOU MUST add citations to every paragraph and bullet point in your answer,
+but only if a relevant search result has a `citation_url` value.
+
 STEP 1: CHECK FOR citation_url IN EACH SEARCH RESULT
-- Only cite information that has a "citation_url" field in the tool results
-- If no citation_url exists for a piece of information, DO NOT cite it
+- Only cite sources that have a "citation_url" field in the tool search results.
+- If no citation_url exists for a source, DO NOT cite it
 
 STEP 2: USE EXACT CITATION FORMAT
-- Format: [^🔗^](<url>)
+- Mandatory Format: "[^🔗^](<url>)" (no other format is acceptable!)
 - Replace <url> with the EXACT citation_url from the search result
 - Example: if search result citation_url value is "http://ocw.mit.edu", then
   citation format should be [^🔗^](http://ocw.mit.edu)
@@ -69,19 +72,18 @@ STEP 2: USE EXACT CITATION FORMAT
 STEP 3: VERIFY BEFORE RESPONDING
 Before you submit your answer, verify EVERY citation:
 - ✅ Does this URL appear in the tool search results?
-- ✅ Is it formatted as [^🔗^](<url>)?
+- ✅ Is it formatted as [^🔗^](<url>), with ONLY ^🔗^ in the brackets?
+- ✅ Did you add a citation for every relevant search result with a citation_url?
 - ❌ CRITICAL: NEVER make up, guess, or modify URLs
 - ❌ NEVER use any other citation format
-- ❌ NEVER use any hyperlink text except ^🔗^
+- ❌ NEVER use "here" or any other citation hyperlink text except ^🔗^
 
 FORBIDDEN ACTIONS:
 - Creating fake URLs
-- Using "here", "syllabus", "assignmennts" or other hyperlink text
-- Numbered citations like [1] or (1)
-- Plain URLs without the [^🔗^] format
-- Citing information without a citation_url
+- Using "here", "syllabus", "assignments", "discussion #" or any other
+words for citation hyperlink text
 
-REMEMBER: It's better to have NO citation than a WRONG citation.
+REMEMBER: It's better to have NO citation than WRONG citations.
 ======================================================================
 """
 
@@ -94,14 +96,15 @@ question.  The search function already has the resource identifier.
 2. Provide a clear, user-friendly summary of the information retrieved by the tool to
 answer the user's question.
 
-{citations}
-
 Always use the tool results to answer questions, and answer only based on the tool
 output. Do not include the course_id in the query parameter.  The tool always has
 access to the course id.
 VERY IMPORTANT: NEVER USE ANY INFORMATION OUTSIDE OF THE TOOL OUTPUT TO
 ANSWER QUESTIONS.  If no results are returned, say you could not find any relevant
-information."""
+information.
+
+{citations}
+"""
 
 
 PROMPT_SYLLABUS_CANVAS = """You are an assistant named Tim, helping users answer

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -51,31 +51,23 @@ needed. Then perform a relevant search and send back the best results.
 """
 
 PROMPT_CITATIONS = """
-🚨 MANDATORY CITATION REQUIREMENTS - NO EXCEPTIONS 🚨
+🚨 CITATION REQUIREMENTS 🚨
 
-YOU MUST add citations to every paragraph and bullet point in your answer,
-for every relevant search result that has a non-null `citation_url` value.
+For every paragraph and bullet point in your answer,
+check if the relevant search results for that paragraph have a `citation_url` value.
+If no, YOU MUST NOT add a citation.
+If yes, YOU MUST add citations to the paragraph in the correct format, described below.
 
 CITATION FORMAT - FOLLOW EXACTLY:
-- CORRECT FORMAT is [^🔗^](citation_url)
-- Replace "citation_url" with the actual URL from the search results
+- CORRECT FORMAT is [^🔗^](url) where url == search_result.citation_url
 - This is the ONLY acceptable hyperlink format
-- Use this format for EVERY SINGLE citation or other link in your response
-
-FORBIDDEN LINKS (NEVER USE THESE):
-- [here](url)
-- [title](url)
-REPEAT: NEVER USE THE ABOVE FOR LINKS!
-
-EXAMPLES:
-CORRECT: "Machine learning involves training algorithms.[^🔗^](https://example.com/ml)"
-WRONG: "Machine learning involves training algorithms. [source](https://example.com/ml)"
-WRONG: "Visit the website: [course title](https://example.com/ml)[^🔗^](https://example.com/ml)"
-WRONG: "Visit the website [here](https://example.com/ml)[^🔗^](https://example.com/ml)"
+- DO NOT ADD ANY CITATION URL THAT IS NOT PRESENT IN SEARCH RESULTS!
 
 VERIFICATION CHECKLIST:
-- Does every citation use ONLY `[^🔗^](citation_url)`? (If no, FIX IT!)
-- Are you using ANY other citation format? (If yes, FIX IT!)
+- Does every citation use ONLY `[^🔗^](url)` where url == search_result.citation_url?
+  (If no, REMOVE IT!)
+- Are you using ANY other format? (If yes, FIX IT!)
+- Does the citation url appear in the search results? (If no, REMOVE IT!)
 """
 
 PROMPT_SYLLABUS = """You are an assistant named Tim, helping users answer questions

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -258,9 +258,15 @@ def _content_file_search(url, params, *, exclude_canvas=True):
             simplified_result = {
                 "chunk_content": result.get("chunk_content"),
                 "run_title": result.get("run_title"),
-                "citation_url": result.get("url"),
-                "citation_title": result.get("title") or result.get("content_title"),
             }
+            if result.get("url"):
+                simplified_result.update(
+                    {
+                        "citation_url": result.get("url"),
+                        "citation_title": result.get("title")
+                        or result.get("content_title"),
+                    }
+                )
             simplified_results.append(simplified_result)
         full_output = {
             "results": simplified_results,

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -155,11 +155,16 @@ def test_search_content_files(  # noqa: PLR0913
     )
     assert len(results["results"]) == len(content_chunk_results["results"])
     for idx, result in enumerate(results["results"]):
-        assert result["citation_url"] == content_chunk_results["results"][idx]["url"]
-        assert result["citation_title"] == (
-            content_chunk_results["results"][idx]["title"]
-            or content_chunk_results["results"][idx]["content_title"]
-        )
+        if content_chunk_results["results"][idx]["url"]:
+            assert (
+                result["citation_url"] == content_chunk_results["results"][idx]["url"]
+            )
+            assert result["citation_title"] == (
+                content_chunk_results["results"][idx]["title"]
+                or content_chunk_results["results"][idx]["content_title"]
+            )
+        else:
+            assert "citation_url" not in result
 
 
 @pytest.mark.parametrize("exclude_canvas", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7989 and https://github.com/mitodl/learn-ai/pull/276

### Description (What does it do?)
- Only includes `citation_url` and `citation_title` attributes in content file search results if `citation_url` is not null.
- Tweaks the citation prompt to reduce the frequency of hallucinatory urls and incorrect citation formats (based on a mix of experimentation and AI prompt improvement suggestions).


### How can this be tested?
Set the following in `backend.local.env`:
  - CANVAS_TUTOR_DEMO_RUN_READABLE_IDS=["14566-kaleba:20211202+canvas", "34642-15.095_FA25"]
  - AI_CITED_PROMPTS=["syllabus", "syllabus_canvas"]
  - Disable any lansgmith env values
 
Go to the following urls:
- http://ai.open.odl.local:8003/?rec_prompt=&tab=SyllabusCanvasGPT&syllabus_prompt=&syllabus_canvas_prompt= : canvas course with citation urls.  Ask the default question, you should likely get at least 1 citation url, and it should be included in the search results (expand the metadata at the bottom of the page to see).
- http://ai.open.odl.local:8003/?rec_prompt=&tab=SyllabusCanvasGPT&syllabus_prompt=&syllabus_canvas_prompt=&syllabus_readable_id=34642-15.095_FA25 : canvas course without citation urls.  Ask the default question, you should get an answer that does not include any citations.
- http://ai.open.odl.local:8003/?rec_prompt=&tab=SyllabusGPT : MITx Online course with no citation_url values.  The default question should return a response with no citations.
- http://ai.open.odl.local:8003/?rec_prompt=&tab=SyllabusGPT&syllabus_resource=2813 : OCW course with citation_urls.  The default question should return a response with properly formatted citations.
