### PR TITLE
fix object id for canvas totur bot

### DIFF
--- a/ai_chatbots/consumers.py
+++ b/ai_chatbots/consumers.py
@@ -613,7 +613,7 @@ class CanvasTutorBotHttpConsumer(BaseBotHttpConsumer):
         object_id_field: Optional[str] = None,
     ) -> tuple[str, list[str]]:
         """Set the edx_module_id as the default object id field"""
-        object_id_field = "object_id_field"
+        object_id_field = "object_id"
         return super().prepare_response(serializer, object_id_field=object_id_field)
 
     async def create_checkpointer(
@@ -626,7 +626,7 @@ class CanvasTutorBotHttpConsumer(BaseBotHttpConsumer):
             user=self.scope.get("user", None),
             dj_session_key=self.session_key,
             agent=self.ROOM_NAME,
-            object_id=serializer.validated_data.get("object_id_field"),
+            object_id=serializer.data.get("object_id"),
         )
 
 

--- a/ai_chatbots/consumers_test.py
+++ b/ai_chatbots/consumers_test.py
@@ -684,6 +684,17 @@ async def canvas_test_tutor_agent_handle(
     )
     assert mock_http_consumer_send.send_headers.call_count == 1
 
+    user_chat = await UserChatSession.objects.aget(
+        thread_id=canvas_tutor_consumer.thread_id,
+        user=canvas_tutor_consumer.scope["user"],
+        title=data["message"],
+        agent="TutorBot",
+    )
+
+    assert user_chat is not None
+
+    assert user_chat.object_id == "run1 - Problem Set 1"
+
 
 async def test_video_gpt_create_chatbot(
     mocker, mock_http_consumer_send, video_gpt_consumer, async_user

--- a/ai_chatbots/serializers.py
+++ b/ai_chatbots/serializers.py
@@ -153,10 +153,17 @@ class CanvasTutorChatRequestSerializer(ChatRequestSerializer):
 
     problem_set_title = serializers.CharField(required=True, allow_blank=False)
     run_readable_id = serializers.CharField(required=True, allow_blank=False)
-    object_id_field = serializers.SerializerMethodField()
+    object_id = serializers.SerializerMethodField()
 
-    def get_object_id_field(self, obj):
+    def get_object_id(self, obj):
         return f"{obj.get('run_readable_id', '')} - {obj.get('problem_set_title', '')}"
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        attrs["object_id"] = (
+            f"{attrs.get('run_readable_id', '')} - {attrs.get('problem_set_title', '')}"
+        )
+        return attrs
 
 
 class LLMModelSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/8233

### Description (What does it do?)
The canvas tutor chat does not currently populate the object id. This fixes the issue

### How can this be tested?
Go to the Canvas Tutor bot tab and start a new thread
Write a message to the bot

from the shell run
```
from ai_chatbots.models import *
UserChatSession.objects.last().__dict__
```

the `object_id` field should not be blank
