### PR TITLE
Adjust metadata writes

### DIFF
--- a/ai_chatbots/api.py
+++ b/ai_chatbots/api.py
@@ -37,6 +37,7 @@ from posthog.ai.langchain import CallbackHandler
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from ai_chatbots.constants import WRITES_MAPPING
 from ai_chatbots.models import DjangoCheckpoint, TutorBotOutput, UserChatSession
 from main.utils import now_in_utc
 
@@ -700,10 +701,12 @@ def _create_checkpoint_metadata(
     tutor_meta: dict, message: dict, step: int, thread_id: str
 ) -> dict:
     """Create metadata for the checkpoint based on message type."""
-    source = (
-        "input" if message.get("kwargs", {}).get("type") == "HumanMessage" else "loop"
-    )
-    writes = {"__start__": {"messages": [message], **tutor_meta}}
+    writes = None
+    message_type = message.get("kwargs", {}).get("type", None)
+    source = "input" if message_type == HumanMessage.__name__ else "loop"
+    container = WRITES_MAPPING.get(message_type, None)
+    if container:
+        writes = {container: {"messages": [message], **tutor_meta}}
 
     return {
         "step": step,

--- a/ai_chatbots/api_test.py
+++ b/ai_chatbots/api_test.py
@@ -1605,12 +1605,14 @@ def test_create_tutor_checkpoints_includes_metadata():
     assert len(result) == 2
 
     # Check that metadata is included in checkpoint writes
-    for checkpoint in result:
+    for idx, checkpoint in enumerate(result):
         metadata = checkpoint.metadata
         writes = metadata.get("writes", {})
 
         # The writes should include the tutor metadata
-        start_writes = writes.get("__start__", writes.get("agent"))
+        key = next(iter(writes.keys()))
+        assert key == "__start__" if idx == 0 else "agent"
+        start_writes = writes.get(key)
         assert start_writes["user_id"] == "test_user_123"
         assert start_writes["course_id"] == "course_456"
         assert start_writes["custom_field"] == "custom_value"

--- a/ai_chatbots/api_test.py
+++ b/ai_chatbots/api_test.py
@@ -1610,7 +1610,7 @@ def test_create_tutor_checkpoints_includes_metadata():
         writes = metadata.get("writes", {})
 
         # The writes should include the tutor metadata
-        start_writes = writes.get("__start__", {})
+        start_writes = writes.get("__start__", writes.get("agent"))
         assert start_writes["user_id"] == "test_user_123"
         assert start_writes["course_id"] == "course_456"
         assert start_writes["custom_field"] == "custom_value"

--- a/ai_chatbots/checkpointers_test.py
+++ b/ai_chatbots/checkpointers_test.py
@@ -253,7 +253,7 @@ async def test_calculate_writes_with_state_attributes(has_messages):
 
     assert calculate_writes(checkpoint) == (
         {
-            "__start__": {
+            "agent": {
                 "messages": [
                     {
                         "lc": 1,
@@ -354,7 +354,7 @@ async def test_aput_adds_writes_when_missing():
     assert "writes" in saved_checkpoint.metadata
 
     expected_writes = {
-        "__start__": {
+        "agent": {
             "messages": [
                 {
                     "lc": 1,
@@ -394,9 +394,15 @@ async def test_aput_preserves_existing_writes():
         "channel_values": {
             "messages": [
                 {
-                    "content": "Test message",
-                    "type": "human",
-                }
+                    "lc": 1,
+                    "type": "constructor",
+                    "id": ["langchain", "schema", "messages", "HumanMessage"],
+                    "kwargs": {
+                        "content": "Test message",
+                        "type": "human",
+                        "id": "test-msg-1",
+                    },
+                },
             ]
         },
     }
@@ -433,9 +439,15 @@ async def test_aput_includes_state_in_writes():
         "channel_values": {
             "messages": [
                 {
-                    "content": "Test message",
-                    "type": "human",
-                }
+                    "lc": 1,
+                    "type": "constructor",
+                    "id": ["langchain", "schema", "messages", "HumanMessage"],
+                    "kwargs": {
+                        "content": "Test message",
+                        "type": "human",
+                        "id": "test-msg-1",
+                    },
+                },
             ],
             "intent_history": ["test_intent"],
             "tutor_metadata": {"subject": "science"},

--- a/ai_chatbots/constants.py
+++ b/ai_chatbots/constants.py
@@ -52,7 +52,8 @@ class ChatbotCookie:
         """
         Represent the cookie as a string
         """
-        expire_str = (
-            f"Max-Age={self.max_age}" if self.max_age is not None else ""
-        )
+        expire_str = f"Max-Age={self.max_age}" if self.max_age is not None else ""
         return f"{self.name}={self.value};Path={self.path};{expire_str};"
+
+
+WRITES_MAPPING = {"human": "__start__", "ai": "agent", "tool": "tools"}


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/learn-ai/pull/301

### Description (What does it do?)
Rachel noticed that the child key for `writes` in the metadata should differ based on the message type: `__start__` for human messages, `tools` for tool messages, `ai` for AI messages.   The code was always using `__start__`, this PR fixes that.



### How can this be tested?
- You can revert the last ai_chatbots migration and then rerun, then look at the checkpoints created for `TutorBotOutputs`.  
  - For human message checkpoints, the metadata `writes` attribute should start with `"__start__": {"messages":`.
  - For ai message checkpoints, the metadata `writes` attribute should start with `"agent": {"messages":`.
- Use the tutorbot and at least one other bot to ask questions, then view the checkpoints' metadata for each.  
  - For human message checkpoints, the metadata `writes` attribute should start with `"__start__": {"messages":`.
  - For ai message checkpoints, the metadata `writes` attribute should start with `"agent": {"messages":`.
  - For tool message checkpoints, the metadata `writes` attribute should start with `"tools": {"messages":`.
