### PR TITLE
temporarily limit canvas response keys

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -23,15 +23,6 @@ from langgraph.graph import MessagesState, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode, create_react_agent, tools_condition
 from langgraph.prebuilt.chat_agent_executor import AgentState
-from open_learning_ai_tutor.message_tutor import message_tutor
-from open_learning_ai_tutor.prompts import get_system_prompt
-from open_learning_ai_tutor.tools import tutor_tools
-from open_learning_ai_tutor.utils import (
-    filter_out_system_messages,
-    json_to_intent_list,
-    json_to_messages,
-    tutor_output_to_json,
-)
 from openai import BadRequestError
 from posthog.ai.langchain import CallbackHandler
 from typing_extensions import TypedDict
@@ -46,6 +37,15 @@ from ai_chatbots.api import (
 )
 from ai_chatbots.prompts import SYSTEM_PROMPT_MAPPING
 from ai_chatbots.utils import get_django_cache, request_with_token
+from open_learning_ai_tutor.message_tutor import message_tutor
+from open_learning_ai_tutor.prompts import get_system_prompt
+from open_learning_ai_tutor.tools import tutor_tools
+from open_learning_ai_tutor.utils import (
+    filter_out_system_messages,
+    json_to_intent_list,
+    json_to_messages,
+    tutor_output_to_json,
+)
 
 log = logging.getLogger(__name__)
 
@@ -689,8 +689,12 @@ def get_canvas_problem_set(run_readable_id: str, problem_set_title: str) -> str:
     api_url = f"{settings.PROBLEM_SET_URL}{run_readable_id}/{problem_set_title}/"
 
     response = request_with_token(api_url, {}, timeout=10)
-
-    return response.json()
+    response = response.json()
+    return {
+        key: value
+        for key, value in response.items()
+        if key in ["problem_set", "solution_set"]
+    }
 
 
 def get_matching_content(api_results: json, edx_module_id: str):

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -11,11 +11,6 @@ from django.conf import settings
 from langchain_community.chat_models import ChatLiteLLM
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableBinding
-from open_learning_ai_tutor.constants import Intent
-from open_learning_ai_tutor.utils import (
-    filter_out_system_messages,
-    tutor_output_to_json,
-)
 from openai import BadRequestError
 
 from ai_chatbots.chatbots import (
@@ -41,6 +36,11 @@ from ai_chatbots.models import TutorBotOutput
 from ai_chatbots.proxies import LiteLLMProxy
 from ai_chatbots.tools import SearchToolSchema
 from main.test_utils import assert_json_equal
+from open_learning_ai_tutor.constants import Intent
+from open_learning_ai_tutor.utils import (
+    filter_out_system_messages,
+    tutor_output_to_json,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -791,7 +791,7 @@ def test_get_canvas_problem_set(mocker):
 
     problem_api_results = {
         "problem_set": "test problem set",
-        "solution": "test solution",
+        "solution_set": "test solution",
     }
 
     mocker.patch(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8555

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/2512
adds support for canvas problem and solution sets to consist of multiple files

We need to temporarily restrict the canvas response to the old keys so that that pr can be deployed before we deploy the corresponding change to open-learning-ai-tutor that depends on it

## How can this be tested?
Canvas tutor bot should work normally