### PR TITLE
Enhancements to RAG evaluation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,5 +222,11 @@ A management command (`rag_evaluation`) has been provided to calculate various e
 - `models`: Comma-delimited list of models that the chatbots will use to answer questions. If none are provided, it will use all the enabled `ai_chatbots.models.LLMModel` objects in the database, so make sure have all the necessary API keys in your environment.
 - `eval_model`: The LLM model that will act as a "judge" and calculate some of the metrics. The default is `gpt-4o-mini`.
 - `bots`: Comma-delimited list of bots to evaluate. If not provided, all chatbots will be evaluated.
+- `data-file`: Input data file containing questions and expected answers. See test_json/rag_evaluation.json for the required format.
+- `prompts`: If true, include alternative prompts to test against in addition to the default prompt per chatbot.
+- `prompts-file`: The file containing alternative prompts to test. See `test_json/rag_evaluation_prompts.json` for the required format.
+- `output-file`: The file to write results to. If not specified, results will only be sent to stdout.
+- `timeout`: The max amount of seconds to wait before aborting a test case and moving on to the next. Default is 360.
+- `max-concurrent`: The max number of test cases to run concurrently. Default is 1.
 
 Make sure that you have the `LEARN_ACCESS_TOKEN` env variable set, otherwise most bots will not return valid contentfile search results.

--- a/ai_chatbots/conftest.py
+++ b/ai_chatbots/conftest.py
@@ -16,6 +16,12 @@ from ai_chatbots.factories import (
 from main.factories import UserFactory
 
 
+@pytest.fixture
+def mock_stdout(mocker):
+    """Create mock stdout for testing."""
+    return mocker.Mock()
+
+
 @pytest.fixture(autouse=True)
 def mock_settings(settings):
     """Langsmith API should be blank for most tests"""

--- a/ai_chatbots/evaluation/base.py
+++ b/ai_chatbots/evaluation/base.py
@@ -44,9 +44,10 @@ class EvaluationConfig:
 class BaseBotEvaluator(ABC):
     """Abstract base class for bot-specific evaluators."""
 
-    def __init__(self, bot_class, bot_name: str):
+    def __init__(self, bot_class, bot_name: str, *, data_file: Optional[str] = None):
         self.bot_class = bot_class
         self.bot_name = bot_name
+        self.data_file = data_file or "test_json/rag_evaluation.json"
 
     @abstractmethod
     def load_test_cases(self) -> list[TestCaseSpec]:

--- a/ai_chatbots/evaluation/evaluators.py
+++ b/ai_chatbots/evaluation/evaluators.py
@@ -5,9 +5,8 @@ from typing import Any, Optional
 from langchain_core.messages import AIMessage
 
 from ai_chatbots import chatbots
+from ai_chatbots.evaluation.base import BaseBotEvaluator, TestCaseSpec
 from main.test_utils import load_json_with_settings
-
-from .base import BaseBotEvaluator, TestCaseSpec
 
 
 class RecommendationBotEvaluator(BaseBotEvaluator):
@@ -15,7 +14,7 @@ class RecommendationBotEvaluator(BaseBotEvaluator):
 
     def load_test_cases(self) -> list[TestCaseSpec]:
         """Load recommendation bot test cases."""
-        test_data = load_json_with_settings("test_json/rag_evaluation.json")
+        test_data = load_json_with_settings(self.data_file)
         return [
             TestCaseSpec(
                 question=case_data["question"],
@@ -73,7 +72,7 @@ class SyllabusBotEvaluator(BaseBotEvaluator):
 
     def load_test_cases(self) -> list[TestCaseSpec]:
         """Load syllabus bot test cases."""
-        test_data = load_json_with_settings("test_json/rag_evaluation.json")
+        test_data = load_json_with_settings(self.data_file)
         return [
             TestCaseSpec(
                 question=case_data["question"],
@@ -131,7 +130,7 @@ class VideoGPTBotEvaluator(BaseBotEvaluator):
 
     def load_test_cases(self) -> list[TestCaseSpec]:
         """Load video GPT bot test cases."""
-        test_data = load_json_with_settings("test_json/rag_evaluation.json")
+        test_data = load_json_with_settings(self.data_file)
         return [
             TestCaseSpec(
                 question=case_data["question"],
@@ -189,7 +188,7 @@ class TutorBotEvaluator(BaseBotEvaluator):
 
     def load_test_cases(self) -> list[TestCaseSpec]:
         """Load tutor bot test cases."""
-        test_data = load_json_with_settings("test_json/rag_evaluation.json")
+        test_data = load_json_with_settings(self.data_file)
         return [
             TestCaseSpec(
                 question=case_data["question"],

--- a/ai_chatbots/evaluation/orchestrator.py
+++ b/ai_chatbots/evaluation/orchestrator.py
@@ -1,9 +1,11 @@
 """Orchestrator for running RAG evaluations across multiple bots and models."""
 
 import os
+from json import JSONDecodeError
 from typing import Optional
 
 import deepeval
+from deepeval.evaluate import AsyncConfig, ErrorConfig
 from deepeval.evaluate.types import EvaluationResult
 from deepeval.metrics import (
     AnswerRelevancyMetric,
@@ -15,11 +17,11 @@ from deepeval.metrics import (
 from django.core.management.base import OutputWrapper
 
 from ai_chatbots.api import get_langsmith_prompt
+from ai_chatbots.evaluation.base import EvaluationConfig
+from ai_chatbots.evaluation.evaluators import BOT_EVALUATORS
+from ai_chatbots.evaluation.reporting import EvaluationReporter
+from ai_chatbots.evaluation.timeout_wrapper import wrap_metrics_with_timeout
 from main.test_utils import load_json_with_settings
-
-from .base import EvaluationConfig
-from .evaluators import BOT_EVALUATORS
-from .reporting import EvaluationReporter
 
 
 class EvaluationOrchestrator:
@@ -34,6 +36,7 @@ class EvaluationOrchestrator:
         models: list[str],
         evaluation_model: str,
         metric_thresholds: Optional[dict[str, float]] = None,
+        timeout_seconds: int = 360,
     ) -> EvaluationConfig:
         """Create evaluation configuration with metrics."""
         if metric_thresholds is None:
@@ -74,120 +77,173 @@ class EvaluationOrchestrator:
             ),
         ]
 
+        # Wrap metrics with timeout functionality
+        timeout_wrapped_metrics = wrap_metrics_with_timeout(metrics, timeout_seconds)
+
         return EvaluationConfig(
             models=models,
             evaluation_model=evaluation_model,
-            metrics=metrics,
+            metrics=timeout_wrapped_metrics,
             confident_api_key=os.environ.get("CONFIDENT_AI_API_KEY"),
         )
 
-    async def run_evaluation(  # noqa: C901, PLR0912
+    def _load_prompts_data(self, prompts_file: str) -> dict:
+        """Load alternative prompts from file if enabled."""
+        prompts_data = {}
+
+        prompts_file = prompts_file or "test_json/rag_evaluation_prompts.json"
+        try:
+            prompts_data = load_json_with_settings(prompts_file)
+            self.stdout.write(f"Loaded alternative prompts from {prompts_file}")
+        except (FileNotFoundError, JSONDecodeError):
+            self.stdout.write(f"Warning: {prompts_file} not found or invalid")
+        return prompts_data
+
+    async def _collect_test_cases_for_bot(
+        self,
+        bot_name: str,
+        config: EvaluationConfig,
+        *,
+        data_file: Optional[str],
+        use_prompts: Optional[bool],
+        prompts_data: Optional[dict],
+    ) -> list:
+        """Collect test cases for a specific bot with all models and prompts."""
+        if bot_name not in BOT_EVALUATORS:
+            self.stdout.write(f"Warning: Unknown bot '{bot_name}', skipping")
+            return []
+
+        bot_class, evaluator_class = BOT_EVALUATORS[bot_name]
+        evaluator = evaluator_class(bot_class, bot_name, data_file=data_file)
+
+        # Load and validate test cases for this bot
+        bot_test_cases = evaluator.load_test_cases()
+        self.stdout.write(f"Loaded {len(bot_test_cases)} test cases for {bot_name}")
+
+        test_cases = []
+
+        # Get prompts for this bot (default + alternatives)
+        bot_prompts = [None]  # Default prompt (None means use bot's default)
+        if use_prompts and bot_name in prompts_data:
+            bot_prompts.extend(prompts_data[bot_name])
+
+        # Evaluate each model with each prompt
+        for model in config.models:
+            for prompt in bot_prompts:
+                # Resolve prompt details
+                if prompt is None:
+                    prompt_label = "default"
+                    prompt_text = None
+                else:
+                    prompt_label = prompt["name"]
+                    prompt_text = prompt.get("text") or get_langsmith_prompt(
+                        prompt_label
+                    )
+
+                if prompt_label != "default" and not prompt_text:
+                    self.stdout.write(f"No prompt text for '{prompt_label}', skipping")
+                    continue
+
+                self.stdout.write(
+                    f"Evaluating {bot_name} with {model} using {prompt_label}"
+                )
+
+                try:
+                    model_test_cases = await evaluator.evaluate_model(
+                        model,
+                        bot_test_cases,
+                        instructions=prompt_text,
+                        prompt_label=prompt_label,
+                    )
+                    test_cases.extend(model_test_cases)
+
+                    # Log responses for debugging
+                    for test_case in model_test_cases:
+                        self.stdout.write(
+                            f"Response for '{test_case.input}' ({prompt_label}): "
+                            f"{test_case.actual_output[:100]}..."
+                        )
+
+                except Exception as e:  # noqa: BLE001
+                    self.stdout.write(
+                        f"Error on {bot_name} with {model} and {prompt_label}: {e}"
+                    )
+                    continue
+
+        return test_cases
+
+    def _run_deepeval_evaluation(
+        self, test_cases: list, config: EvaluationConfig, max_concurrent: int
+    ) -> EvaluationResult:
+        """Run the actual DeepEval evaluation."""
+        self.stdout.write(
+            f"Running evaluation on {len(test_cases)} test cases "
+            f"with max_concurrent={max_concurrent}"
+        )
+
+        if not test_cases:
+            self.stdout.write("No test cases available - skipping evaluation")
+            return EvaluationResult(test_results=[], confident_link=None)
+
+        # Create AsyncConfig and log its settings
+        async_config = AsyncConfig(
+            max_concurrent=max_concurrent,
+            throttle_value=0,  # No throttling by default
+        )
+        self.stdout.write(
+            f"AsyncConfig: max_concurrent={async_config.max_concurrent}, "
+            f"throttle_value={async_config.throttle_value}"
+        )
+
+        if max_concurrent < len(test_cases):
+            self.stdout.write(
+                f"NOTE: DeepEval may show 'Evaluating {len(test_cases)} "
+                f"test case(s) in parallel' but will actually limit to "
+                f"{max_concurrent} concurrent executions"
+            )
+
+        return deepeval.evaluate(
+            test_cases=test_cases,
+            metrics=config.metrics,
+            error_config=ErrorConfig(ignore_errors=True),
+            async_config=async_config,
+        )
+
+    async def run_evaluation(  # noqa: PLR0913
         self,
         config: EvaluationConfig,
         *,
         bot_names: Optional[list[str]] = None,
-        use_prompts: bool = True,
+        data_file: Optional[str] = None,
+        use_prompts: Optional[bool] = True,
         prompts_file: Optional[str] = None,
+        max_concurrent: Optional[int] = 10,
     ) -> EvaluationResult:
         """Run evaluation across specified bots and models."""
-        # Set up DeepEval logging if API key is available
+        # Set up DeepEval authentication if API key is available
         if config.confident_api_key:
             deepeval.login_with_confident_api_key(config.confident_api_key)
 
         # Determine which bots to evaluate
-        if not bot_names:
-            bot_names = list(BOT_EVALUATORS.keys())
+        bot_names = bot_names or list(BOT_EVALUATORS.keys())
 
         # Load alternative prompts if enabled
-        prompts_data = {}
-        if use_prompts:
-            prompts_file = prompts_file or "test_json/rag_evaluation_prompts.json"
-            try:
-                prompts_data = load_json_with_settings(prompts_file)
-                self.stdout.write(f"Loaded alternative prompts from {prompts_file}")
-            except FileNotFoundError:
-                self.stdout.write(
-                    f"Warning: {prompts_file} not found, using default prompts only"
-                )
-                use_prompts = False
-
-        self.stdout.write(
-            f"Evaluating bots: {', '.join(bot_names)}, "
-            f"models: {', '.join(config.models)}"
-        )
+        prompts_data = self._load_prompts_data(prompts_file) if use_prompts else {}
 
         # Collect all test cases
         test_cases = []
         for bot_name in bot_names:
-            if bot_name not in BOT_EVALUATORS:
-                self.stdout.write(f"Warning: Unknown bot '{bot_name}', skipping")
-                continue
+            bot_test_cases = await self._collect_test_cases_for_bot(
+                bot_name,
+                config,
+                data_file=data_file,
+                use_prompts=use_prompts,
+                prompts_data=prompts_data,
+            )
+            test_cases.extend(bot_test_cases)
 
-            bot_class, evaluator_class = BOT_EVALUATORS[bot_name]
-            evaluator = evaluator_class(bot_class, bot_name)
-
-            # Load and validate test cases for this bot
-            bot_test_cases = evaluator.load_test_cases()
-            self.stdout.write(f"Loaded {len(bot_test_cases)} test cases for {bot_name}")
-
-            # Get prompts for this bot (default + alternatives)
-            bot_prompts = [None]  # Default prompt (None means use bot's default)
-            if use_prompts and bot_name in prompts_data:
-                bot_prompts.extend(prompts_data[bot_name])
-
-            # Evaluate each model with each prompt
-            for model in config.models:
-                for prompt in bot_prompts:
-                    if prompt is None:
-                        prompt_label = "default"
-                        prompt_text = None
-                    else:
-                        prompt_label = prompt["name"]
-                        prompt_text = prompt.get("text") or get_langsmith_prompt(
-                            prompt_label
-                        )
-                    if prompt_label != "default" and not prompt_text:
-                        self.stdout.write(
-                            f"No prompt text for '{prompt_label}', skipping"
-                        )
-                        continue
-                    self.stdout.write(
-                        f"Evaluating {bot_name} with {model} using {prompt_label}"
-                    )
-
-                    try:
-                        model_test_cases = await evaluator.evaluate_model(
-                            model,
-                            bot_test_cases,
-                            instructions=prompt_text,
-                            prompt_label=prompt_label,
-                        )
-                        test_cases.extend(model_test_cases)
-
-                        # Log responses for debugging
-                        for test_case in model_test_cases:
-                            self.stdout.write(
-                                f"Response for '{test_case.input}' ({prompt_label}): "
-                                f"{test_case.actual_output[:100]}..."
-                            )
-
-                    except Exception as e:  # noqa: BLE001
-                        self.stdout.write(
-                            f"Error on {bot_name} with {model} and {prompt_label}: {e}"
-                        )
-                        continue
-
-        # Run DeepEval evaluation
-        self.stdout.write(f"Running evaluation on {len(test_cases)} test cases")
-
-        if not test_cases:
-            self.stdout.write("No test cases available - skipping evaluation")
-            # Create an empty results object to avoid errors
-            results = EvaluationResult(test_results=[], confident_link=None)
-        else:
-            results = deepeval.evaluate(test_cases=test_cases, metrics=config.metrics)
-
-        # Generate report
+        # Run evaluation and generate report
+        results = self._run_deepeval_evaluation(test_cases, config, max_concurrent)
         self.reporter.generate_report(results, config.models, bot_names)
 
         return results

--- a/ai_chatbots/evaluation/reporting_test.py
+++ b/ai_chatbots/evaluation/reporting_test.py
@@ -1,32 +1,121 @@
 """Unit tests for evaluation reporting classes."""
 
-from unittest.mock import Mock
+import tempfile
+from pathlib import Path
 
 import pandas as pd
 import pytest
 from deepeval.evaluate.types import EvaluationResult
 
-from .reporting import EvaluationReporter, SummaryReporter
+from ai_chatbots.evaluation.reporting import (
+    DualOutputWrapper,
+    EvaluationReporter,
+    SummaryReporter,
+)
+
+
+@pytest.fixture
+def reporter(mock_stdout):
+    """Create reporter for testing."""
+    return EvaluationReporter(mock_stdout)
+
+
+class TestDualOutputWrapper:
+    """Test cases for DualOutputWrapper class."""
+
+    def test_initialization_without_file(self, mocker):
+        """Test DualOutputWrapper initialization without file."""
+        stdout = mocker.Mock()
+        wrapper = DualOutputWrapper(stdout, file_path=None)
+
+        assert wrapper.stdout is stdout
+        assert wrapper.file_path is None
+        assert wrapper.file is None
+
+    def test_initialization_with_file(self, mocker):
+        """Test DualOutputWrapper initialization with file."""
+        stdout = mocker.Mock()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            temp_path = temp_file.name
+
+            try:
+                wrapper = DualOutputWrapper(stdout, file_path=temp_path)
+
+                assert wrapper.stdout is stdout
+                assert wrapper.file_path == temp_path
+                assert wrapper.file is not None
+
+                # Clean up
+                wrapper.close()
+            finally:
+                Path(temp_path).unlink(missing_ok=True)
+
+    def test_write_without_file(self, mocker):
+        """Test write method without file output."""
+        stdout = mocker.Mock()
+        wrapper = DualOutputWrapper(stdout, file_path=None)
+
+        wrapper.write("test message", style_func=None, ending=None)
+
+        stdout.write.assert_called_once_with(
+            "test message", style_func=None, ending=None
+        )
+
+    def test_write_with_file(self, mocker):
+        """Test write method with file output."""
+        stdout = mocker.Mock()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            temp_path = temp_file.name
+
+        try:
+            wrapper = DualOutputWrapper(stdout, file_path=temp_path)
+
+            wrapper.write("test message", ending="\n")
+
+            # Verify stdout was called
+            stdout.write.assert_called_once_with(
+                "test message", style_func=None, ending="\n"
+            )
+
+            # Verify file content
+            wrapper.close()
+            with Path(temp_path).open("r") as f:
+                content = f.read()
+                assert "test message\n" in content
+
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    def test_context_manager(self, mocker):
+        """Test DualOutputWrapper as context manager."""
+        stdout = mocker.Mock()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            temp_path = temp_file.name
+
+        try:
+            with DualOutputWrapper(stdout, file_path=temp_path) as wrapper:
+                assert wrapper.file is not None
+                wrapper.write("context test")
+
+            with Path(temp_path).open("r") as f:
+                content = f.read()
+                assert "context test" in content
+
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
 
 
 class TestEvaluationReporter:
     """Test cases for EvaluationReporter."""
 
     @pytest.fixture
-    def mock_stdout(self):
-        """Create mock stdout for testing."""
-        return Mock()
-
-    @pytest.fixture
-    def reporter(self, mock_stdout):
-        """Create reporter for testing."""
-        return EvaluationReporter(mock_stdout)
-
-    @pytest.fixture
-    def mock_evaluation_results(self):
+    def mock_evaluation_results(self, mocker):
         """Create mock evaluation results."""
         # Create mock test results
-        test_result1 = Mock()
+        test_result1 = mocker.Mock()
         test_result1.additional_metadata = {
             "bot_name": "recommendation",
             "model": "gpt-4",
@@ -36,13 +125,13 @@ class TestEvaluationReporter:
         test_result1.name = "recommendation-gpt-4"
 
         # Create mock metrics data
-        metric1 = Mock()
+        metric1 = mocker.Mock()
         metric1.name = "ContextualRelevancy"
         metric1.score = 0.85
         metric1.success = True
         metric1.reason = ""
 
-        metric2 = Mock()
+        metric2 = mocker.Mock()
         metric2.name = "AnswerRelevancy"
         metric2.score = 0.45
         metric2.success = False
@@ -51,7 +140,7 @@ class TestEvaluationReporter:
         test_result1.metrics_data = [metric1, metric2]
 
         # Create second test result
-        test_result2 = Mock()
+        test_result2 = mocker.Mock()
         test_result2.additional_metadata = {
             "bot_name": "syllabus",
             "model": "gpt-3.5",
@@ -60,7 +149,7 @@ class TestEvaluationReporter:
         }
         test_result2.name = "syllabus-gpt-3.5"
 
-        metric3 = Mock()
+        metric3 = mocker.Mock()
         metric3.name = "ContextualRelevancy"
         metric3.score = 0.75
         metric3.success = True
@@ -69,7 +158,7 @@ class TestEvaluationReporter:
         test_result2.metrics_data = [metric3]
 
         # Create mock evaluation result
-        results = Mock(spec=EvaluationResult)
+        results = mocker.Mock(spec=EvaluationResult)
         results.test_results = [test_result1, test_result2]
 
         return results
@@ -77,6 +166,38 @@ class TestEvaluationReporter:
     def test_reporter_initialization(self, reporter, mock_stdout):
         """Test reporter initialization."""
         assert reporter.stdout == mock_stdout
+
+    def test_normalize_score_for_aggregation(self, reporter):
+        """Test score normalization for different metric types."""
+        assert reporter.normalize_score_for_aggregation("Hallucination", 0.0) == 1.0
+        assert reporter.normalize_score_for_aggregation("Hallucination", 0.3) == 0.7
+        assert reporter.normalize_score_for_aggregation("Hallucination", 1.0) == 0.0
+        assert (
+            reporter.normalize_score_for_aggregation("hallucinationmetric", 0.2) == 0.8
+        )
+
+        # Test other metrics (should remain unchanged)
+        assert (
+            reporter.normalize_score_for_aggregation("ContextualRelevancy", 0.8) == 0.8
+        )
+        assert reporter.normalize_score_for_aggregation("AnswerRelevancy", 0.5) == 0.5
+        assert (
+            reporter.normalize_score_for_aggregation("ContextualPrecision", 1.0) == 1.0
+        )
+        assert reporter.normalize_score_for_aggregation("ContextualRecall", 0.0) == 0.0
+
+    def test_is_inverse_metric(self, reporter):
+        """Test inverse metric detection using settings."""
+        assert reporter.is_inverse_metric("Hallucination") is True
+        assert reporter.is_inverse_metric("hallucination") is True
+        assert reporter.is_inverse_metric("HallucinationMetric") is True
+        assert reporter.is_inverse_metric("hallucinationmetric") is True
+
+        # Non-inverse metrics
+        assert reporter.is_inverse_metric("ContextualRelevancy") is False
+        assert reporter.is_inverse_metric("AnswerRelevancy") is False
+        assert reporter.is_inverse_metric("ContextualPrecision") is False
+        assert reporter.is_inverse_metric("UnknownMetric") is False
 
     def test_create_results_dataframe(self, reporter, mock_evaluation_results):
         """Test creation of results DataFrame."""
@@ -176,13 +297,65 @@ class TestEvaluationReporter:
         assert "ContextualRelevancy" in output_text
         assert "AnswerRelevancy" in output_text
 
+    def test_model_comparison_hallucination_sorting(self, reporter, mock_stdout):
+        """Test that model comparison correctly sorts hallucination metrics (lower is better)."""
+        data = [
+            {
+                "model": "gpt-4",
+                "metric": "Hallucination",
+                "score": 0.3,
+            },  # Worse (higher hallucination)
+            {
+                "model": "gpt-3.5",
+                "metric": "Hallucination",
+                "score": 0.1,
+            },  # Better (lower hallucination)
+            {"model": "claude", "metric": "Hallucination", "score": 0.2},  # Middle
+        ]
+        df = pd.DataFrame(data)
+
+        reporter.model_comparison(df)
+
+        # Verify output was generated
+        assert mock_stdout.write.call_count > 0
+
+        calls = [call[0][0] for call in mock_stdout.write.call_args_list]
+        output_text = " ".join(calls)
+
+        # For hallucination, the ranking should be: gpt-3.5 (0.1), claude (0.2), gpt-4 (0.3)
+        # since lower hallucination scores are better
+        assert "Hallucination" in output_text
+        assert "gpt-3.5" in output_text
+        assert "gpt-4" in output_text
+        assert "claude" in output_text
+
     def test_overall_performance(self, reporter, mock_stdout):
         """Test overall performance calculation."""
         data = [
-            {"model": "gpt-4", "prompt_label": "default", "score": 0.85},
-            {"model": "gpt-4", "prompt_label": "#1", "score": 0.45},
-            {"model": "gpt-3.5", "prompt_label": "default", "score": 0.75},
-            {"model": "gpt-3.5", "prompt_label": "#1", "score": 0.65},
+            {
+                "model": "gpt-4",
+                "prompt_label": "default",
+                "metric": "ContextualRelevancy",
+                "score": 0.85,
+            },
+            {
+                "model": "gpt-4",
+                "prompt_label": "#1",
+                "metric": "AnswerRelevancy",
+                "score": 0.45,
+            },
+            {
+                "model": "gpt-3.5",
+                "prompt_label": "default",
+                "metric": "ContextualRelevancy",
+                "score": 0.75,
+            },
+            {
+                "model": "gpt-3.5",
+                "prompt_label": "#1",
+                "metric": "AnswerRelevancy",
+                "score": 0.65,
+            },
         ]
         df = pd.DataFrame(data)
 
@@ -194,6 +367,54 @@ class TestEvaluationReporter:
         calls = [call[0][0] for call in mock_stdout.write.call_args_list]
         output_text = " ".join(calls)
         assert "OVERALL PERFORMANCE" in output_text
+        assert "gpt-4" in output_text
+        assert "gpt-3.5" in output_text
+
+    def test_overall_performance_with_hallucination_normalization(
+        self, reporter, mock_stdout
+    ):
+        """Test that overall performance correctly normalizes hallucination scores."""
+        data = [
+            {
+                "model": "gpt-4",
+                "metric": "ContextualRelevancy",
+                "score": 0.8,
+                "prompt_label": "default",
+            },
+            {
+                "model": "gpt-4",
+                "metric": "Hallucination",
+                "score": 0.2,
+                "prompt_label": "default",
+            },  # Lower is better
+            {
+                "model": "gpt-3.5",
+                "metric": "ContextualRelevancy",
+                "score": 0.6,
+                "prompt_label": "default",
+            },
+            {
+                "model": "gpt-3.5",
+                "metric": "Hallucination",
+                "score": 0.4,
+                "prompt_label": "default",
+            },  # Lower is better
+        ]
+        df = pd.DataFrame(data)
+
+        # Calculate expected normalized averages:
+        # gpt-4: (0.8 + (1.0 - 0.2)) / 2 = (0.8 + 0.8) / 2 = 0.8
+        # gpt-3.5: (0.6 + (1.0 - 0.4)) / 2 = (0.6 + 0.6) / 2 = 0.6
+
+        reporter.overall_performance(df)
+
+        # Verify that output was generated and contains model rankings
+        assert mock_stdout.write.call_count > 0
+        calls = [call[0][0] for call in mock_stdout.write.call_args_list]
+        output_text = " ".join(calls)
+
+        assert "OVERALL PERFORMANCE" in output_text
+        # gpt-4 should rank higher than gpt-3.5 when hallucination is properly normalized
         assert "gpt-4" in output_text
         assert "gpt-3.5" in output_text
 
@@ -275,36 +496,31 @@ class TestSummaryReporter:
     """Test cases for SummaryReporter."""
 
     @pytest.fixture
-    def mock_stdout(self):
-        """Create mock stdout for testing."""
-        return Mock()
-
-    @pytest.fixture
     def summary_reporter(self, mock_stdout):
         """Create summary reporter for testing."""
         return SummaryReporter(mock_stdout)
 
     @pytest.fixture
-    def mock_simple_results(self):
+    def mock_simple_results(self, mocker):
         """Create simple mock results for summary testing."""
-        test_result = Mock()
+        test_result = mocker.Mock()
         test_result.additional_metadata = {
             "bot_name": "recommendation",
             "model": "gpt-4",
             "prompt_label": "default",
         }
 
-        metric1 = Mock()
+        metric1 = mocker.Mock()
         metric1.name = "ContextualRelevancy"
         metric1.success = True
 
-        metric2 = Mock()
+        metric2 = mocker.Mock()
         metric2.name = "AnswerRelevancy"
         metric2.success = False
 
         test_result.metrics_data = [metric1, metric2]
 
-        results = Mock(spec=EvaluationResult)
+        results = mocker.Mock(spec=EvaluationResult)
         results.test_results = [test_result]
 
         return results
@@ -339,9 +555,11 @@ class TestSummaryReporter:
         assert "Failed:" in output_text
         assert "Pass Rate:" in output_text
 
-    def test_generate_summary_empty_results(self, summary_reporter, mock_stdout):
+    def test_generate_summary_empty_results(
+        self, summary_reporter, mock_stdout, mocker
+    ):
         """Test summary generation with empty results."""
-        empty_results = Mock(spec=EvaluationResult)
+        empty_results = mocker.Mock(spec=EvaluationResult)
         empty_results.test_results = []
 
         summary_reporter.generate_summary(empty_results)
@@ -353,14 +571,14 @@ class TestSummaryReporter:
         output_text = " ".join(calls)
         assert "No test results to summarize" in output_text
 
-    def test_generate_summary_calculations(self, summary_reporter, mock_stdout):
+    def test_generate_summary_calculations(self, summary_reporter, mock_stdout, mocker):
         """Test summary calculations are correct."""
         # Create results with known pass/fail counts
         test_results = []
 
         # Create 3 test results with 2 metrics each (6 total metrics)
         for i in range(3):
-            test_result = Mock()
+            test_result = mocker.Mock()
             test_result.additional_metadata = {
                 "bot_name": f"bot{i}",
                 "model": "gpt-4",
@@ -368,18 +586,18 @@ class TestSummaryReporter:
             }
 
             # First metric passes, second fails
-            metric1 = Mock()
+            metric1 = mocker.Mock()
             metric1.name = "Metric1"
             metric1.success = True
 
-            metric2 = Mock()
+            metric2 = mocker.Mock()
             metric2.name = "Metric2"
             metric2.success = False
 
             test_result.metrics_data = [metric1, metric2]
             test_results.append(test_result)
 
-        results = Mock(spec=EvaluationResult)
+        results = mocker.Mock(spec=EvaluationResult)
         results.test_results = test_results
 
         summary_reporter.generate_summary(results)
@@ -397,13 +615,13 @@ class TestSummaryReporter:
 class TestReportingIntegration:
     """Integration tests for reporting functionality."""
 
-    def test_end_to_end_reporting(self):
+    def test_end_to_end_reporting(self, mocker):
         """Test end-to-end reporting workflow."""
-        mock_stdout = Mock()
+        mock_stdout = mocker.Mock()
         reporter = EvaluationReporter(mock_stdout)
 
         # Create comprehensive test data
-        test_result = Mock()
+        test_result = mocker.Mock()
         test_result.additional_metadata = {
             "bot_name": "recommendation",
             "model": "gpt-4",
@@ -412,7 +630,7 @@ class TestReportingIntegration:
         }
         test_result.name = "recommendation-gpt-4"
 
-        metric = Mock()
+        metric = mocker.Mock()
         metric.name = "ContextualRelevancy"
         metric.score = 0.85
         metric.success = True
@@ -420,7 +638,7 @@ class TestReportingIntegration:
 
         test_result.metrics_data = [metric]
 
-        results = Mock(spec=EvaluationResult)
+        results = mocker.Mock(spec=EvaluationResult)
         results.test_results = [test_result]
 
         # Generate full report
@@ -445,15 +663,14 @@ class TestReportingIntegration:
         for section in required_sections:
             assert section in output_text
 
-    def test_both_reporters_together(self):
+    def test_both_reporters_together(self, mocker, mock_stdout):
         """Test using both evaluation and summary reporters."""
-        mock_stdout = Mock()
 
         evaluation_reporter = EvaluationReporter(mock_stdout)
         summary_reporter = SummaryReporter(mock_stdout)
 
         # Create test data
-        results = Mock(spec=EvaluationResult)
+        results = mocker.Mock(spec=EvaluationResult)
         results.test_results = []
 
         # Use both reporters

--- a/ai_chatbots/evaluation/timeout_wrapper.py
+++ b/ai_chatbots/evaluation/timeout_wrapper.py
@@ -1,0 +1,194 @@
+"""Timeout wrapper for DeepEval metrics to prevent hanging test cases."""
+
+import asyncio
+import threading
+from typing import Any
+
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+
+class TimeoutMetricWrapper(BaseMetric):
+    """Wrapper that adds timeout functionality to any DeepEval metric."""
+
+    def __init__(self, base_metric: BaseMetric, timeout_seconds: int = 180):
+        """Initialize the timeout wrapper.
+
+        Args:
+            base_metric: The original metric to wrap
+            timeout_seconds: Maximum time allowed for metric execution
+                (default: 360 seconds)
+        """
+        self.base_metric = base_metric
+        self.timeout_seconds = timeout_seconds
+
+        # Copy attributes from base metric
+        super().__init__()
+        self.threshold = getattr(base_metric, "threshold", 0.5)
+        self.include_reason = getattr(base_metric, "include_reason", True)
+
+        # Initialize metric state
+        self.score = None
+        self.success = None
+        self.reason = None
+        self.error = None
+
+    def measure(self, test_case: LLMTestCase) -> float:
+        """Execute the base metric with timeout protection."""
+        return self._execute_with_timeout(self.base_metric.measure, test_case)
+
+    async def a_measure(self, test_case: LLMTestCase) -> float:
+        """Execute the base metric asynchronously with timeout protection."""
+        if hasattr(self.base_metric, "a_measure"):
+            return await self._execute_async_with_timeout(
+                self.base_metric.a_measure, test_case
+            )
+        else:
+            # Fallback to sync measure in executor
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None, self._execute_with_timeout, self.base_metric.measure, test_case
+            )
+
+    def _execute_with_timeout(self, method: Any, test_case: LLMTestCase) -> float:
+        """Execute a method with timeout using threading."""
+        result = {"score": None, "error": None, "completed": False}
+
+        def target():
+            try:
+                score = method(test_case)
+                # Copy over the attributes from the base metric
+                self.score = self.base_metric.score
+                self.success = self.base_metric.success
+                self.reason = getattr(self.base_metric, "reason", None)
+                self.error = getattr(self.base_metric, "error", None)
+
+                result["score"] = score
+                result["completed"] = True
+            except Exception as e:  # noqa: BLE001
+                result["error"] = str(e)
+                result["completed"] = True
+
+        thread = threading.Thread(target=target, daemon=True)
+        thread.start()
+        thread.join(timeout=self.timeout_seconds)
+
+        if thread.is_alive():
+            # Thread is still running, timeout occurred
+            self.score = 0.0
+            self.success = False
+            self.reason = (
+                f"Metric execution timed out after {self.timeout_seconds} seconds"
+            )
+            self.error = f"Timeout after {self.timeout_seconds} seconds"
+            return 0.0
+
+        if result["error"]:
+            self.error = result["error"]
+            raise RuntimeError(result["error"])
+
+        if not result["completed"]:
+            self.score = 0.0
+            self.success = False
+            self.reason = "Metric execution failed to complete"
+            self.error = "Execution failed to complete"
+            return 0.0
+
+        return result["score"]
+
+    async def _execute_async_with_timeout(
+        self, method: Any, test_case: LLMTestCase
+    ) -> float:
+        """Execute an async method with timeout."""
+        try:
+            score = await asyncio.wait_for(
+                method(test_case), timeout=self.timeout_seconds
+            )
+            # Copy over the attributes from the base metric
+            self.score = self.base_metric.score
+            self.success = self.base_metric.success
+            self.reason = getattr(self.base_metric, "reason", None)
+            self.error = getattr(self.base_metric, "error", None)
+
+        except TimeoutError:
+            self.score = 0.0
+            self.success = False
+            self.reason = (
+                f"Metric execution timed out after {self.timeout_seconds} seconds"
+            )
+            self.error = f"Timeout after {self.timeout_seconds} seconds"
+            return 0.0
+        except Exception as e:
+            self.error = str(e)
+            raise
+        else:
+            return score
+
+    def is_successful(self) -> bool:
+        """Check if the metric evaluation was successful."""
+        if self.success is not None:
+            return self.success
+        # Fallback: check if we have a valid score and no error
+        return self.score is not None and self.error is None
+
+    @property
+    def __name__(self):
+        """Return the original metric name for identification."""
+        return getattr(
+            self.base_metric, "__name__", self.base_metric.__class__.__name__
+        )
+
+    def __str__(self):
+        """Return the original metric name as string."""
+        return str(self.base_metric)
+
+    def __repr__(self):
+        """Return the original metric representation."""
+        return repr(self.base_metric)
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the base metric if not found in wrapper."""
+        # Handle special naming attributes that DeepEval might use
+        if name in ["__class__", "__name__", "__module__"] and hasattr(
+            self.base_metric, name
+        ):
+            return getattr(self.base_metric, name)
+
+        # This ensures any additional attributes or methods from the base metric
+        # are accessible
+        if hasattr(self.base_metric, name):
+            return getattr(self.base_metric, name)
+        error_msg = f"'{type(self).__name__}' object has no attribute '{name}'"
+        raise AttributeError(error_msg)
+
+
+def wrap_metrics_with_timeout(
+    metrics: list[BaseMetric], timeout_seconds: int = 180
+) -> list[BaseMetric]:
+    """Wrap a list of metrics with timeout functionality.
+
+    Args:
+        metrics: List of metrics to wrap
+        timeout_seconds: Timeout in seconds (default: 180 = 3 minutes)
+
+    Returns:
+        List of timeout-wrapped metrics
+    """
+    wrapped_metrics = []
+    for metric in metrics:
+        # Create a dynamic class that inherits from TimeoutMetricWrapper
+        # but has the same name as the original metric
+        original_class_name = metric.__class__.__name__
+
+        # Create a new class dynamically with the original metric's name
+        DynamicTimeoutWrapper = type(
+            original_class_name,  # Class name
+            (TimeoutMetricWrapper,),  # Base classes
+            {},  # Class attributes
+        )
+
+        # Create instance of the dynamic wrapper class
+        wrapped_metric = DynamicTimeoutWrapper(metric, timeout_seconds)
+        wrapped_metrics.append(wrapped_metric)
+
+    return wrapped_metrics

--- a/ai_chatbots/evaluation/timeout_wrapper_test.py
+++ b/ai_chatbots/evaluation/timeout_wrapper_test.py
@@ -1,0 +1,259 @@
+"""Unit tests for timeout wrapper functionality."""
+
+import asyncio
+import time
+
+import pytest
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+from ai_chatbots.evaluation.timeout_wrapper import (
+    TimeoutMetricWrapper,
+    wrap_metrics_with_timeout,
+)
+
+
+class MockMetric(BaseMetric):
+    """Mock metric for testing purposes."""
+
+    def __init__(
+        self, name="MockMetric", delay=0, *, should_raise=False, async_support=False
+    ):
+        super().__init__()
+        self._name = name  # Store name privately since __name__ is a property
+        self.delay = delay
+        self.should_raise = should_raise
+        self.async_support = async_support
+        self.threshold = 0.5
+        self.include_reason = True
+
+        # Initialize metric state
+        self.score = None
+        self.success = None
+        self.reason = None
+        self.error = None
+
+    @property
+    def __name__(self):
+        """Override __name__ property."""
+        return self._name
+
+    def measure(self, test_case: LLMTestCase) -> float:
+        """Mock measure method with configurable behavior."""
+        _ = test_case  # Mark as used
+        if self.delay > 0:
+            time.sleep(self.delay)
+
+        if self.should_raise:
+            msg = "Mock metric error"
+            raise RuntimeError(msg)
+
+        # Set mock results
+        self.score = 0.8
+        self.success = True
+        self.reason = "Mock reason"
+
+        return 0.8
+
+    async def a_measure(self, test_case: LLMTestCase) -> float:
+        """Mock async measure method."""
+        _ = test_case  # Mark as used
+        if not self.async_support:
+            msg = "Mock metric doesn't support async"
+            raise AttributeError(msg)
+
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+
+        if self.should_raise:
+            msg = "Mock async metric error"
+            raise RuntimeError(msg)
+
+        # Set mock results
+        self.score = 0.9
+        self.success = True
+        self.reason = "Mock async reason"
+
+        return 0.9
+
+
+class TestTimeoutMetricWrapper:
+    """Test cases for TimeoutMetricWrapper class."""
+
+    def test_initialization(self):
+        """Test TimeoutMetricWrapper initialization with custom and default values."""
+        base_metric = MockMetric("TestMetric")
+
+        # Test custom timeout
+        wrapper = TimeoutMetricWrapper(base_metric, timeout_seconds=60)
+        assert wrapper.base_metric is base_metric
+        assert wrapper.timeout_seconds == 60
+        assert wrapper.threshold == 0.5
+        assert wrapper.include_reason is True
+        assert wrapper.score is None
+        assert wrapper.success is None
+
+        # Test default timeout
+        wrapper_default = TimeoutMetricWrapper(base_metric)
+        assert wrapper_default.timeout_seconds == 180
+
+    def test_sync_measure_success_and_timeout(self):
+        """Test sync measure method for both success and timeout scenarios."""
+        test_case = LLMTestCase(input="test", actual_output="output")
+
+        # Test successful execution
+        base_metric = MockMetric("TestMetric")
+        wrapper = TimeoutMetricWrapper(base_metric, timeout_seconds=5)
+        score = wrapper.measure(test_case)
+
+        assert score == 0.8
+        assert wrapper.score == 0.8
+        assert wrapper.success is True
+        assert wrapper.reason == "Mock reason"
+
+        # Test timeout
+        slow_metric = MockMetric("SlowMetric", delay=2)
+        timeout_wrapper = TimeoutMetricWrapper(slow_metric, timeout_seconds=1)
+        timeout_score = timeout_wrapper.measure(test_case)
+
+        assert timeout_score == 0.0
+        assert timeout_wrapper.score == 0.0
+        assert timeout_wrapper.success is False
+        assert "timed out after 1 seconds" in timeout_wrapper.reason
+
+    def test_sync_measure_exception(self):
+        """Test sync measure method with exception handling."""
+        base_metric = MockMetric("ErrorMetric", should_raise=True)
+        wrapper = TimeoutMetricWrapper(base_metric, timeout_seconds=5)
+        test_case = LLMTestCase(input="test", actual_output="output")
+
+        with pytest.raises(RuntimeError, match="Mock metric error"):
+            wrapper.measure(test_case)
+        assert wrapper.error == "Mock metric error"
+
+    @pytest.mark.asyncio
+    async def test_async_measure_success_and_timeout(self):
+        """Test async measure method for both success and timeout scenarios."""
+        test_case = LLMTestCase(input="test", actual_output="output")
+
+        # Test successful async execution
+        async_metric = MockMetric("AsyncMetric", async_support=True)
+        wrapper = TimeoutMetricWrapper(async_metric, timeout_seconds=5)
+        score = await wrapper.a_measure(test_case)
+
+        assert score == 0.9
+        assert wrapper.score == 0.9
+        assert wrapper.success is True
+        assert wrapper.reason == "Mock async reason"
+
+        # Test async timeout
+        slow_async_metric = MockMetric("SlowAsyncMetric", delay=2, async_support=True)
+        timeout_wrapper = TimeoutMetricWrapper(slow_async_metric, timeout_seconds=1)
+        timeout_score = await timeout_wrapper.a_measure(test_case)
+
+        assert timeout_score == 0.0
+        assert timeout_wrapper.score == 0.0
+        assert timeout_wrapper.success is False
+        assert "timed out after 1 seconds" in timeout_wrapper.reason
+
+    @pytest.mark.asyncio
+    async def test_async_measure_exception(self):
+        """Test async measure method with exception handling."""
+        error_metric = MockMetric(
+            "AsyncErrorMetric", should_raise=True, async_support=True
+        )
+        wrapper = TimeoutMetricWrapper(error_metric, timeout_seconds=5)
+        test_case = LLMTestCase(input="test", actual_output="output")
+
+        with pytest.raises(RuntimeError, match="Mock async metric error"):
+            await wrapper.a_measure(test_case)
+        assert wrapper.error == "Mock async metric error"
+
+    def test_is_successful_logic(self):
+        """Test is_successful method with various states."""
+        base_metric = MockMetric("TestMetric")
+        wrapper = TimeoutMetricWrapper(base_metric)
+
+        # Test explicit success values
+        wrapper.success = True
+        assert wrapper.is_successful() is True
+
+        wrapper.success = False
+        assert wrapper.is_successful() is False
+
+        # Test fallback logic
+        wrapper.success = None
+        wrapper.score = 0.8
+        wrapper.error = None
+        assert wrapper.is_successful() is True
+
+        wrapper.score = None
+        assert wrapper.is_successful() is False
+
+        wrapper.score = 0.8
+        wrapper.error = "Some error"
+        assert wrapper.is_successful() is False
+
+    def test_wrapper_interface(self):
+        """Test wrapper interface, attribute delegation, and naming."""
+        base_metric = MockMetric("TestMetric")
+        base_metric.custom_attr = "custom_value"
+        wrapper = TimeoutMetricWrapper(base_metric)
+
+        # Test naming properties
+        assert wrapper.__name__ == "TestMetric"
+        assert str(wrapper) == str(base_metric)
+        assert repr(wrapper) == repr(base_metric)
+
+        # Test attribute delegation
+        assert wrapper.custom_attr == "custom_value"
+
+        # Test error for non-existent attribute
+        with pytest.raises(AttributeError):
+            _ = wrapper.non_existent_attr
+
+
+class TestWrapMetricsWithTimeout:
+    """Test cases for wrap_metrics_with_timeout function."""
+
+    def test_wrap_metrics_functionality(self):
+        """Test wrapping metrics with various scenarios."""
+        # Test single metric
+        base_metric = MockMetric("TestMetric")
+        wrapped_metrics = wrap_metrics_with_timeout([base_metric], timeout_seconds=30)
+
+        assert len(wrapped_metrics) == 1
+        wrapped = wrapped_metrics[0]
+        assert isinstance(wrapped, TimeoutMetricWrapper)
+        assert wrapped.base_metric is base_metric
+        assert wrapped.timeout_seconds == 30
+        assert wrapped.__class__.__name__ == "MockMetric"
+
+        # Test multiple metrics
+        metrics = [MockMetric("Metric1"), MockMetric("Metric2")]
+        wrapped_multiple = wrap_metrics_with_timeout(metrics, timeout_seconds=60)
+
+        assert len(wrapped_multiple) == 2
+        for i, wrapped in enumerate(wrapped_multiple):
+            assert isinstance(wrapped, TimeoutMetricWrapper)
+            assert wrapped.base_metric is metrics[i]
+            assert wrapped.timeout_seconds == 60
+
+        # Test empty list
+        assert wrap_metrics_with_timeout([]) == []
+
+    def test_wrap_with_default_timeout(self):
+        """Test wrapping with default timeout and functionality preservation."""
+        base_metric = MockMetric("TestMetric")
+        wrapped_metrics = wrap_metrics_with_timeout([base_metric])
+
+        assert len(wrapped_metrics) == 1
+        wrapped = wrapped_metrics[0]
+        assert wrapped.timeout_seconds == 180  # Default timeout
+
+        # Test that functionality is preserved
+        test_case = LLMTestCase(input="test", actual_output="output")
+        score = wrapped.measure(test_case)
+        assert score == 0.8  # Same as original metric
+        assert wrapped.score == 0.8
+        assert wrapped.success is True

--- a/ai_chatbots/management/commands/convert_eval_csv_to_json.py
+++ b/ai_chatbots/management/commands/convert_eval_csv_to_json.py
@@ -1,0 +1,152 @@
+"""Django management command to convert CSV evaluation data to JSON format."""
+
+import csv
+import json
+from pathlib import Path
+
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    """Convert CSV evaluation data to JSON format for RAG evaluations."""
+
+    help = "Convert CSV evaluation data to JSON format suitable for RAG evaluations"
+
+    def add_arguments(self, parser):
+        """Add command arguments."""
+        parser.add_argument(
+            "--csv-file",
+            dest="csv_file_path",
+            required=True,
+            help="Path to the input CSV file",
+        )
+        parser.add_argument(
+            "--output-file",
+            dest="output_file_path",
+            required=True,
+            help="Path for the output JSON file",
+        )
+        parser.add_argument(
+            "--course-id",
+            dest="course_id",
+            required=True,
+            help="Course ID to use in the JSON structure",
+        )
+        parser.add_argument(
+            "--bot",
+            dest="bot",
+            required=True,
+            choices=[
+                "syllabus",
+                "canvas_syllabus",
+                "recommendation",
+                "tutor",
+                "videogpt",
+            ],
+            help="Bot type to use as entity name in JSON structure",
+        )
+        parser.add_argument(
+            "--encoding",
+            dest="encoding",
+            default="utf-8",
+            help="CSV file encoding (default: utf-8)",
+        )
+
+    def handle(self, **options):
+        """Execute the command."""
+        csv_file_path = Path(options["csv_file_path"])
+        output_file_path = Path(options["output_file_path"])
+        course_id = options["course_id"]
+        encoding = options["encoding"]
+        bot = options["bot"]
+
+        # Validate input file exists
+        if not csv_file_path.exists():
+            self.stdout.write(self.style.ERROR(f"CSV file not found: {csv_file_path}"))
+            return
+
+        # Create output directory if it doesn't exist
+        output_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        syllabus_data = []
+
+        try:
+            with csv_file_path.open(encoding=encoding) as csvfile:
+                reader = csv.reader(csvfile)
+
+                # Skip the first row (headers)
+                headers = next(reader)
+                self.stdout.write(f"Headers: {headers}")
+
+                # Process each row
+                for row_num, row in enumerate(reader, start=2):
+                    # Skip empty rows
+                    min_columns = 5
+                    if len(row) < min_columns or not row[2].strip():
+                        continue
+
+                    # Column C is index 2 (question)
+                    question = row[2].strip()
+
+                    # Column D is index 3 (answer)
+                    answer = row[3].strip()
+
+                    # Column E is index 4 (accuracy)
+                    accuracy = row[4].strip()
+
+                    # Determine expected_output based on accuracy
+                    expected_output = answer if accuracy.lower() == "accurate" else ""
+
+                    # Create JSON object
+                    json_obj = {
+                        "question": question,
+                        "extra_state": {
+                            "course_id": [course_id],
+                            "collection_name": [None],
+                            "exclude_canvas": [False]
+                            if bot == "canvas_syllabus"
+                            else [True],
+                        },
+                        "expected_output": expected_output,
+                        "expected_tools": ["search_content_files"],
+                    }
+
+                    syllabus_data.append(json_obj)
+
+                    # Print first few for verification
+                    max_verification_rows = 5
+                    if row_num <= max_verification_rows:
+                        self.stdout.write(f"Row {row_num}:")
+                        self.stdout.write(f"Question: {question[:50]}...")
+                        self.stdout.write(f"Accuracy: '{accuracy}'")
+                        self.stdout.write(
+                            f"Has expected output: {bool(expected_output)}"
+                        )
+
+            # Create final JSON structure
+            final_json = {bot: syllabus_data}
+
+            # Write to file
+            with output_file_path.open("w", encoding="utf-8") as jsonfile:
+                json.dump(final_json, jsonfile, indent=2, ensure_ascii=False)
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Conversion complete! Created {len(syllabus_data)} entries."
+                )
+            )
+            self.stdout.write(
+                self.style.SUCCESS(f"Output saved to: {output_file_path}")
+            )
+
+        except FileNotFoundError:
+            self.stdout.write(self.style.ERROR(f"File not found: {csv_file_path}"))
+        except UnicodeDecodeError:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Unable to decode file with encoding '{encoding}'. "
+                    "Try a different encoding with --encoding option."
+                )
+            )
+        except (OSError, ValueError) as e:
+            self.stdout.write(self.style.ERROR(f"Error processing file: {e!s}"))

--- a/ai_chatbots/management/commands/rag_evaluation.py
+++ b/ai_chatbots/management/commands/rag_evaluation.py
@@ -4,6 +4,7 @@ from asgiref.sync import async_to_sync
 from django.core.management import BaseCommand
 
 from ai_chatbots.evaluation.orchestrator import EvaluationOrchestrator
+from ai_chatbots.evaluation.reporting import DualOutputWrapper
 from ai_chatbots.models import LLMModel
 
 
@@ -36,6 +37,13 @@ class Command(BaseCommand):
             default="",
         )
         parser.add_argument(
+            "--data-file",
+            dest="data_file",
+            required=False,
+            help="Specify the data file to use",
+            default=None,
+        )
+        parser.add_argument(
             "--prompts",
             dest="prompts",
             action="store_true",
@@ -48,8 +56,32 @@ class Command(BaseCommand):
             help="Specify the prompts file to use",
             default=None,
         )
+        parser.add_argument(
+            "--output-file",
+            dest="output_file",
+            required=False,
+            help="Specify a file to save the evaluation report (in addition to "
+            "console output)",
+            default=None,
+        )
+        parser.add_argument(
+            "--timeout",
+            dest="timeout",
+            required=False,
+            type=int,
+            help="Timeout in seconds for individual test cases (default: 360)",
+            default=360,
+        )
+        parser.add_argument(
+            "--max-concurrent",
+            dest="max_concurrent",
+            required=False,
+            type=int,
+            help="Maximum number of test cases to run in parallel (default: 1)",
+            default=1,
+        )
 
-    def handle(self, *args, **options):  # noqa: ARG002
+    def handle(self, **options):
         """Run the command using the new evaluation framework."""
         # Parse command line arguments
         models = [m for m in options["models"].split(",") if m] or (
@@ -63,29 +95,48 @@ class Command(BaseCommand):
         )
         evaluation_model = options["eval_model"]
         bot_names = options["bots"].split(",") if options["bots"] else None
+        data_file = options["data_file"] if options["data_file"] else None
         use_prompts = options["prompts"] or options["prompts_file"] is not None
         prompts_file = options["prompts_file"]
+        output_file = options["output_file"]
+        timeout_seconds = options["timeout"]
+        max_concurrent = options["max_concurrent"]
 
-        # Create evaluation orchestrator
-        orchestrator = EvaluationOrchestrator(self.stdout)
+        # Create output wrapper (dual output if file specified, otherwise normal stdout)
+        if output_file:
+            output_wrapper = DualOutputWrapper(self.stdout, output_file)
+            self.stdout.write(f"Report will be saved to: {output_file}")
+        else:
+            output_wrapper = self.stdout
 
-        # Create evaluation configuration
-        config = orchestrator.create_evaluation_config(
-            models=models,
-            evaluation_model=evaluation_model,
-        )
+        try:
+            # Create evaluation orchestrator with the appropriate output wrapper
+            orchestrator = EvaluationOrchestrator(output_wrapper)
 
-        # Validate bot names if provided
-        if bot_names:
-            bot_names = orchestrator.validate_bot_names(bot_names)
-            if not bot_names:
-                self.stdout.write("No valid bot names provided. Exiting.")
-                return
+            # Create evaluation configuration
+            config = orchestrator.create_evaluation_config(
+                models=models,
+                evaluation_model=evaluation_model,
+                timeout_seconds=timeout_seconds,
+            )
 
-        # Run evaluation
-        async_to_sync(orchestrator.run_evaluation)(
-            config,
-            bot_names=bot_names,
-            use_prompts=use_prompts,
-            prompts_file=prompts_file,
-        )
+            # Validate bot names if provided
+            if bot_names:
+                bot_names = orchestrator.validate_bot_names(bot_names)
+                if not bot_names:
+                    self.stdout.write("No valid bot names provided. Exiting.")
+                    return
+
+            # Run evaluation
+            async_to_sync(orchestrator.run_evaluation)(
+                config,
+                bot_names=bot_names,
+                data_file=data_file,
+                use_prompts=use_prompts,
+                prompts_file=prompts_file,
+                max_concurrent=max_concurrent,
+            )
+        finally:
+            # Clean up file resources if using DualOutputWrapper
+            if output_file and hasattr(output_wrapper, "close"):
+                output_wrapper.close()

--- a/main/settings.py
+++ b/main/settings.py
@@ -634,6 +634,9 @@ AI_CHATBOTS_COOKIE_MAX_AGE = get_int(
 AI_CITED_PROMPTS = get_list_of_str("AI_CITED_PROMPTS", default=[])
 AI_DEBUG = get_bool("AI_DEBUG", False)  # noqa: FBT003
 AI_DEFAULT_MODEL = get_string(name="AI_DEFAULT_MODEL", default="openai/gpt-4o-mini")
+AI_INVERSE_METRICS = get_list_of_str(
+    "AI_INVERSE_METRICS", default=["hallucination", "hallucinationmetric"]
+)
 AI_DEFAULT_RECOMMENDATION_MODEL = get_string(
     "AI_DEFAULT_RECOMMENDATION_MODEL", AI_DEFAULT_MODEL
 )


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7605

### Description (What does it do?)
- Adds a few options to the `rag_evaluation` management command:
   - a data file to read test cases from
   - an output file to write to
   - a timeout value to abort an individual test case (test cases were sometimes hanging and preventing the evalutation from completing)
   - a concurrency value to specify how many tests should run in parallel
- Adds error and async configs to allow the evaluation to proceed if individual test cases raise an exception, and to allow tests to run simultaneously
- Fixes incorrect summary statistics caused by certain metrics (i.e. hallucination) having an inverse score where 0 = best, 1 = worst, instead of the other way around.


### How can this be tested?
Run the mgmt command and try out some of the new options, for example:

```bash
./manage.py rag_evaluation --models openai/gpt-5-mini,openai/gpt-4o-mini  \
  --eval_model gpt-4o-mini \
  --bots syllabus \
  --data-file test_json/rag_evaluation.json \
  --output-file rag_eval_results.md  \
  --timeout 120 \
  --max-concurrent 4
```