### PR TITLE
Retry tool calls on failed requests to search endpoints

### DIFF
--- a/ai_chatbots/conftest.py
+++ b/ai_chatbots/conftest.py
@@ -1,9 +1,12 @@
+"""Shared pytest fixtures for ai_chatbots tests."""
+
 import json
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
+import httpx
 import pytest
 from asgiref.sync import sync_to_async
 
@@ -56,8 +59,6 @@ def sync_user():
 @pytest.fixture
 def django_session():
     """Create a mock Django session for testing."""
-    from uuid import uuid4
-
     session = Mock()
     session.session_key = f"test_session_{uuid4().hex}"
     session.save = Mock()
@@ -76,9 +77,6 @@ def mock_check_throttles(mocker):
 @pytest.fixture(autouse=True)
 def ai_settings(settings, mocker):
     """Assign default AI settings"""
-    # Reset HTTP client singletons before each test
-    from ai_chatbots import utils
-
     utils.sync_http_client = None
     utils.async_http_client = None
 
@@ -115,12 +113,15 @@ class MockAsyncIterator:
     """An async iterator for testing purposes."""
 
     def __init__(self, seq):
+        """Store the sequence iterator."""
         self.iter = iter(seq)
 
     def __aiter__(self):
+        """Return the iterator itself."""
         return self
 
     async def __anext__(self):
+        """Return the next item or stop iteration."""
         try:
             return next(self.iter)
         except StopIteration:
@@ -238,3 +239,52 @@ def mock_httpx_async_client(mocker):
         return mock_client
 
     return _mock_async_client
+
+
+@pytest.fixture
+def _no_retry_sleep(mocker):
+    """Skip retry sleeps in tests."""
+    mocker.patch.object(utils, "_sleep_before_retry", mocker.AsyncMock())
+
+
+@pytest.fixture
+def httpx_response():
+    """Build a real httpx.Response for tests."""
+
+    def _httpx_response(
+        status_code: int,
+        url: str = "https://api.example.com/test",
+        json_body: dict | None = None,
+    ):
+        kwargs = {
+            "status_code": status_code,
+            "request": httpx.Request("GET", url),
+        }
+        if json_body is not None:
+            kwargs["json"] = json_body
+        return httpx.Response(**kwargs)
+
+    return _httpx_response
+
+
+@pytest.fixture
+def mock_async_get_client(mocker):
+    """Mock an async client with a configurable GET response."""
+
+    def _mock_async_get_client(
+        *,
+        side_effect=None,
+        return_value=None,
+        patch_path: str = "ai_chatbots.utils.get_async_http_client",
+    ):
+        mock_client = mocker.Mock()
+        if side_effect is not None:
+            mock_client.get = mocker.AsyncMock(side_effect=side_effect)
+        else:
+            mock_client.get = mocker.AsyncMock(return_value=return_value)
+        mock_client.post = mocker.AsyncMock()
+        mock_client.aclose = mocker.AsyncMock()
+        mocker.patch(patch_path, return_value=mock_client)
+        return mock_client
+
+    return _mock_async_get_client

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -190,11 +190,6 @@ async def search_courses(
         }
         return json.dumps(full_output)
     except (RequestError, HTTPStatusError):
-        # HTTPStatusError covers terminal upstream failures (e.g. persistent
-        # 502s after the retry budget in async_request_with_token is exhausted).
-        # It is *not* a subclass of RequestError, so it must be caught
-        # explicitly to keep the failure inside this tool's JSON contract
-        # rather than bubbling to the chatbot's generic exception handler.
         log.exception("Error querying MIT API")
         return json.dumps({"error": "An error occurred while searching"})
 

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -7,7 +7,7 @@ from typing import Annotated, Optional
 import pydantic
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from httpx import RequestError
+from httpx import HTTPStatusError, RequestError
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 from pydantic import Field
@@ -189,7 +189,12 @@ async def search_courses(
             "metadata": {"search_url": search_url, "parameters": params},
         }
         return json.dumps(full_output)
-    except RequestError:
+    except (RequestError, HTTPStatusError):
+        # HTTPStatusError covers terminal upstream failures (e.g. persistent
+        # 502s after the retry budget in async_request_with_token is exhausted).
+        # It is *not* a subclass of RequestError, so it must be caught
+        # explicitly to keep the failure inside this tool's JSON contract
+        # rather than bubbling to the chatbot's generic exception handler.
         log.exception("Error querying MIT API")
         return json.dumps({"error": "An error occurred while searching"})
 

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -2,10 +2,12 @@
 
 import json
 
+import httpx
 import pytest
 from httpx import RequestError
 from pydantic_core._pydantic_core import ValidationError
 
+from ai_chatbots import utils
 from ai_chatbots.tools import (
     search_content_files,
     search_courses,
@@ -128,6 +130,33 @@ async def test_httpx_exception(mocker):
         {"q": "physics", "state": {"search_url": ["https://test.edu/search"]}}
     )
     assert result == '{"error": "An error occurred while searching"}'
+
+
+async def test_search_courses_handles_http_status_error(mocker):
+    """
+    A persistent upstream 502 (after retries are exhausted in
+    async_request_with_token) must be caught by search_courses and converted
+    to the JSON error payload, not bubble out as an uncaught HTTPStatusError.
+    Regression test for the production incident where a 502 escaped this
+    tool's narrow ``except RequestError`` clause and corrupted the checkpoint.
+    """
+    mocker.patch.object(utils, "_sleep_before_retry", mocker.AsyncMock())
+
+    error_response = httpx.Response(
+        status_code=502,
+        request=httpx.Request("GET", "https://test.edu/search"),
+    )
+    mock_client = mocker.Mock()
+    mock_client.get = mocker.AsyncMock(return_value=error_response)
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    result = await search_courses.ainvoke(
+        {"q": "physics", "state": {"search_url": ["https://test.edu/search"]}}
+    )
+
+    assert result == '{"error": "An error occurred while searching"}'
+    # Confirm the retry budget was actually exercised before giving up.
+    assert mock_client.get.call_count == 3
 
 
 @pytest.mark.django_db

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -2,12 +2,10 @@
 
 import json
 
-import httpx
 import pytest
 from httpx import RequestError
 from pydantic_core._pydantic_core import ValidationError
 
-from ai_chatbots import utils
 from ai_chatbots.tools import (
     search_content_files,
     search_courses,
@@ -132,23 +130,14 @@ async def test_httpx_exception(mocker):
     assert result == '{"error": "An error occurred while searching"}'
 
 
-async def test_search_courses_handles_http_status_error(mocker):
-    """
-    A persistent upstream 502 (after retries are exhausted in
-    async_request_with_token) must be caught by search_courses and converted
-    to the JSON error payload, not bubble out as an uncaught HTTPStatusError.
-    Regression test for the production incident where a 502 escaped this
-    tool's narrow ``except RequestError`` clause and corrupted the checkpoint.
-    """
-    mocker.patch.object(utils, "_sleep_before_retry", mocker.AsyncMock())
-
-    error_response = httpx.Response(
-        status_code=502,
-        request=httpx.Request("GET", "https://test.edu/search"),
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_search_courses_handles_http_status_error(
+    mock_async_get_client, httpx_response
+):
+    """Persistent 502s should become the tool's JSON error payload."""
+    mock_client = mock_async_get_client(
+        return_value=httpx_response(502, url="https://test.edu/search")
     )
-    mock_client = mocker.Mock()
-    mock_client.get = mocker.AsyncMock(return_value=error_response)
-    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
 
     result = await search_courses.ainvoke(
         {"q": "physics", "state": {"search_url": ["https://test.edu/search"]}}

--- a/ai_chatbots/utils.py
+++ b/ai_chatbots/utils.py
@@ -1,14 +1,18 @@
 """Utility functions for ai chat agents"""
 
 import asyncio
+import json
 import logging
 from enum import Enum
 
 import httpx
+from channels.db import database_sync_to_async
 from django.conf import settings
 from django.core.cache import BaseCache, caches
 from langchain_core.messages import HumanMessage
 from named_enum import ExtendedEnum
+
+from ai_chatbots.models import DjangoCheckpoint
 
 log = logging.getLogger(__name__)
 
@@ -16,11 +20,41 @@ log = logging.getLogger(__name__)
 TOOL_MESSAGE_ID = ["langchain", "schema", "messages", "ToolMessage"]
 AI_MESSAGE_ID = ["langchain", "schema", "messages", "AIMessage"]
 
+# HTTP statuses that indicate transient upstream failures worth retrying.
+# Other 4xx codes are deterministic and should not be retried.
+RETRYABLE_STATUS_CODES = frozenset({408, 429, 502, 503, 504})
+
+# httpx exceptions that represent transient network/transport failures.
+RETRYABLE_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+    httpx.RemoteProtocolError,
+)
+
+# Max retry attempts for transient HTTP failures (1 original + 2 retries).
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_BASE_DELAY = 0.5
+_RETRY_MAX_DELAY = 2.0
+
+
+def _compute_retry_delay(attempt: int) -> float:
+    """Compute a capped exponential backoff delay in seconds."""
+    return min(_RETRY_BASE_DELAY * (2**attempt), _RETRY_MAX_DELAY)
+
+
+async def _sleep_before_retry(attempt: int) -> None:
+    """Sleep before retrying a transient upstream failure."""
+    await asyncio.sleep(_compute_retry_delay(attempt))
+
 
 class HTTPClientManager:
     """Manager for shared HTTP client instances with connection pooling."""
 
     def __init__(self):
+        """Initialize empty shared sync and async HTTP clients."""
         self._sync_client: httpx.Client | None = None
         self._async_client: httpx.AsyncClient | None = None
 
@@ -150,6 +184,22 @@ async def async_request_with_token(url, params, timeout: int = 30):
     blocking the event loop with synchronous HTTP requests. Uses a shared client
     with connection pooling for optimal performance with concurrent requests.
 
+    Transient upstream failures are retried up to ``_RETRY_MAX_ATTEMPTS`` times
+    with a capped exponential backoff. The following are considered transient
+    and trigger a retry:
+
+    - Network/transport exceptions in ``RETRYABLE_EXCEPTIONS`` (connect errors,
+      read/write/pool timeouts, remote protocol errors).
+    - HTTP responses with a status code in ``RETRYABLE_STATUS_CODES``
+      (408, 429, 502, 503, 504).
+
+    Non-retryable responses (including 2xx success and 4xx client errors other
+    than 408/429) are returned to the caller as-is, preserving the existing
+    contract that callers decide what to do via their own ``raise_for_status``.
+    If retries are exhausted for a retryable HTTP status, the final response is
+    returned to the caller. If retries are exhausted for a transport error, the
+    original ``httpx.RequestError`` is reraised.
+
     Args:
         url: The URL to request
         params: Query parameters
@@ -159,12 +209,55 @@ async def async_request_with_token(url, params, timeout: int = 30):
         httpx.Response object with compatible interface to requests.Response
     """
     client = get_async_http_client()
-    return await client.get(
-        url,
-        params=params,
-        headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
-        timeout=timeout,
-    )
+    headers = {"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"}
+
+    for attempt in range(_RETRY_MAX_ATTEMPTS):
+        try:
+            response = await client.get(
+                url,
+                params=params,
+                headers=headers,
+                timeout=timeout,
+            )
+        except RETRYABLE_EXCEPTIONS:
+            if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                raise
+            delay = _compute_retry_delay(attempt)
+            log.warning(
+                (
+                    "Retrying HTTP request to %s after transient transport "
+                    "error; attempt %d/%d in %.1fs"
+                ),
+                url,
+                attempt + 2,
+                _RETRY_MAX_ATTEMPTS,
+                delay,
+                exc_info=True,
+            )
+            await _sleep_before_retry(attempt)
+            continue
+
+        if response.status_code not in RETRYABLE_STATUS_CODES:
+            return response
+
+        if attempt == _RETRY_MAX_ATTEMPTS - 1:
+            return response
+
+        delay = _compute_retry_delay(attempt)
+        log.warning(
+            (
+                "Retrying HTTP request to %s after transient upstream status "
+                "%d; attempt %d/%d in %.1fs"
+            ),
+            url,
+            response.status_code,
+            attempt + 2,
+            _RETRY_MAX_ATTEMPTS,
+            delay,
+        )
+        await _sleep_before_retry(attempt)
+
+    return response
 
 
 def truncate_to_latest_human_message(messages: list) -> list:
@@ -198,11 +291,6 @@ async def save_truncated_checkpoint(thread_id: str, keep_ids: set[str]) -> None:
         thread_id: The thread ID to clean up
         keep_ids: Set of message IDs to keep
     """
-    import json
-
-    from channels.db import database_sync_to_async
-
-    from ai_chatbots.api import DjangoCheckpoint
 
     @database_sync_to_async
     def update_checkpoint():

--- a/ai_chatbots/utils.py
+++ b/ai_chatbots/utils.py
@@ -41,12 +41,12 @@ _RETRY_MAX_DELAY = 2.0
 
 
 def _compute_retry_delay(attempt: int) -> float:
-    """Compute a capped exponential backoff delay in seconds."""
+    """Return the capped exponential backoff delay."""
     return min(_RETRY_BASE_DELAY * (2**attempt), _RETRY_MAX_DELAY)
 
 
 async def _sleep_before_retry(attempt: int) -> None:
-    """Sleep before retrying a transient upstream failure."""
+    """Sleep for the next retry delay."""
     await asyncio.sleep(_compute_retry_delay(attempt))
 
 
@@ -54,7 +54,7 @@ class HTTPClientManager:
     """Manager for shared HTTP client instances with connection pooling."""
 
     def __init__(self):
-        """Initialize empty shared sync and async HTTP clients."""
+        """Initialize shared client slots."""
         self._sync_client: httpx.Client | None = None
         self._async_client: httpx.AsyncClient | None = None
 
@@ -178,27 +178,11 @@ def request_with_token(url, params, follow_redirects, timeout: int = 30):
 
 async def async_request_with_token(url, params, timeout: int = 30):
     """
-    Make an asynchronous HTTP GET request with bearer token authentication.
+        Make an async bearer-authenticated GET request.
 
-    This function should be used in async contexts (like LangGraph tools) to avoid
-    blocking the event loop with synchronous HTTP requests. Uses a shared client
-    with connection pooling for optimal performance with concurrent requests.
-
-    Transient upstream failures are retried up to ``_RETRY_MAX_ATTEMPTS`` times
-    with a capped exponential backoff. The following are considered transient
-    and trigger a retry:
-
-    - Network/transport exceptions in ``RETRYABLE_EXCEPTIONS`` (connect errors,
-      read/write/pool timeouts, remote protocol errors).
-    - HTTP responses with a status code in ``RETRYABLE_STATUS_CODES``
-      (408, 429, 502, 503, 504).
-
-    Non-retryable responses (including 2xx success and 4xx client errors other
-    than 408/429) are returned to the caller as-is, preserving the existing
-    contract that callers decide what to do via their own ``raise_for_status``.
-    If retries are exhausted for a retryable HTTP status, the final response is
-    returned to the caller. If retries are exhausted for a transport error, the
-    original ``httpx.RequestError`` is reraised.
+        Retries transient transport errors and retryable upstream statuses up to
+        ``_RETRY_MAX_ATTEMPTS`` times. Returns the final response, or reraises the
+        last transport error if no response was received.
 
     Args:
         url: The URL to request

--- a/ai_chatbots/utils_test.py
+++ b/ai_chatbots/utils_test.py
@@ -92,93 +92,51 @@ async def test_async_request_with_token(mocker, settings):
     assert response.json() == {"result": "async_success"}
 
 
-@pytest.fixture
-def _no_retry_sleep(mocker):
-    """Patch retry sleep so retry tests run instantly."""
-    mocker.patch.object(utils, "_sleep_before_retry", mocker.AsyncMock())
-
-
-def _httpx_response(status_code: int, url: str = "https://api.example.com/test"):
-    """Build a real httpx.Response so raise_for_status() raises HTTPStatusError."""
-    return httpx.Response(
-        status_code=status_code,
-        request=httpx.Request("GET", url),
-    )
-
-
 @pytest.mark.usefixtures("_no_retry_sleep")
-async def test_async_request_with_token_retries_on_502(mocker, settings):
-    """Transient 502s are retried up to 3 attempts and then succeed."""
-    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
-
-    responses = [
-        _httpx_response(502),
-        _httpx_response(502),
-        _httpx_response(200),
-    ]
-    mock_client = mocker.Mock()
-    mock_client.get = mocker.AsyncMock(side_effect=responses)
-    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
-
-    response = await utils.async_request_with_token(
-        "https://api.example.com/test", {"q": "x"}
-    )
-
-    assert response.status_code == 200
-    assert mock_client.get.call_count == 3
-
-
-@pytest.mark.usefixtures("_no_retry_sleep")
-async def test_async_request_with_token_returns_final_502_after_max_attempts(
-    mocker, settings
+@pytest.mark.parametrize(
+    ("statuses", "expected_status", "expected_calls"),
+    [
+        ([502, 502, 200], 200, 3),
+        ([502, 502, 502], 502, 3),
+        ([404], 404, 1),
+    ],
+    ids=[
+        "retries-on-502-until-success",
+        "returns-final-502-after-exhaustion",
+        "does-not-retry-on-404",
+    ],
+)
+async def test_async_request_with_token_status_handling(
+    mock_async_get_client,
+    httpx_response,
+    statuses,
+    expected_status,
+    expected_calls,
 ):
-    """Three consecutive 502s exhaust the retry budget and return the final response."""
-    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
-
-    mock_client = mocker.Mock()
-    mock_client.get = mocker.AsyncMock(
-        side_effect=[_httpx_response(502) for _ in range(3)]
+    """Handle retryable and non-retryable HTTP statuses correctly."""
+    mock_client = mock_async_get_client(
+        side_effect=[httpx_response(status) for status in statuses]
     )
-    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
 
     response = await utils.async_request_with_token(
         "https://api.example.com/test", {"q": "x"}
     )
 
-    assert response.status_code == 502
-    assert mock_client.get.call_count == 3
+    assert response.status_code == expected_status
+    assert mock_client.get.call_count == expected_calls
 
 
 @pytest.mark.usefixtures("_no_retry_sleep")
-async def test_async_request_with_token_does_not_retry_on_404(mocker, settings):
-    """Deterministic 4xx responses are returned to the caller without retrying."""
-    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
-
-    mock_client = mocker.Mock()
-    mock_client.get = mocker.AsyncMock(return_value=_httpx_response(404))
-    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
-
-    response = await utils.async_request_with_token(
-        "https://api.example.com/test", {"q": "x"}
-    )
-
-    assert response.status_code == 404
-    assert mock_client.get.call_count == 1
-
-
-@pytest.mark.usefixtures("_no_retry_sleep")
-async def test_async_request_with_token_retries_on_connect_error(mocker, settings):
-    """Transient transport exceptions are retried."""
-    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
-
-    mock_client = mocker.Mock()
-    mock_client.get = mocker.AsyncMock(
+async def test_async_request_with_token_retries_on_connect_error(
+    mock_async_get_client, httpx_response
+):
+    """Retry transient transport errors."""
+    mock_client = mock_async_get_client(
         side_effect=[
             httpx.ConnectError("boom"),
-            _httpx_response(200),
+            httpx_response(200),
         ]
     )
-    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
 
     response = await utils.async_request_with_token(
         "https://api.example.com/test", {"q": "x"}
@@ -347,8 +305,6 @@ async def test_truncate_to_latest_human_message_empty(mock_checkpointer):
 @pytest.mark.django_db
 async def test_truncate_checkpoint_messages_filters_messages(mock_checkpointer):
     """Should filter checkpoint messages to only keep specified IDs."""
-    from ai_chatbots.utils import save_truncated_checkpoint
-
     thread_id = mock_checkpointer.session.thread_id
     keep_msg = HumanMessageFactory.create(content="keep")
     checkpoint_data = {
@@ -364,7 +320,7 @@ async def test_truncate_checkpoint_messages_filters_messages(mock_checkpointer):
         checkpoint=json.dumps(checkpoint_data),
     )
 
-    await save_truncated_checkpoint(thread_id, {keep_msg.id})
+    await utils.save_truncated_checkpoint(thread_id, {keep_msg.id})
 
     await database_sync_to_async(checkpoint.refresh_from_db)()
     saved_data = json.loads(checkpoint.checkpoint)

--- a/ai_chatbots/utils_test.py
+++ b/ai_chatbots/utils_test.py
@@ -92,6 +92,102 @@ async def test_async_request_with_token(mocker, settings):
     assert response.json() == {"result": "async_success"}
 
 
+@pytest.fixture
+def _no_retry_sleep(mocker):
+    """Patch retry sleep so retry tests run instantly."""
+    mocker.patch.object(utils, "_sleep_before_retry", mocker.AsyncMock())
+
+
+def _httpx_response(status_code: int, url: str = "https://api.example.com/test"):
+    """Build a real httpx.Response so raise_for_status() raises HTTPStatusError."""
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("GET", url),
+    )
+
+
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_async_request_with_token_retries_on_502(mocker, settings):
+    """Transient 502s are retried up to 3 attempts and then succeed."""
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
+
+    responses = [
+        _httpx_response(502),
+        _httpx_response(502),
+        _httpx_response(200),
+    ]
+    mock_client = mocker.Mock()
+    mock_client.get = mocker.AsyncMock(side_effect=responses)
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    response = await utils.async_request_with_token(
+        "https://api.example.com/test", {"q": "x"}
+    )
+
+    assert response.status_code == 200
+    assert mock_client.get.call_count == 3
+
+
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_async_request_with_token_returns_final_502_after_max_attempts(
+    mocker, settings
+):
+    """Three consecutive 502s exhaust the retry budget and return the final response."""
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
+
+    mock_client = mocker.Mock()
+    mock_client.get = mocker.AsyncMock(
+        side_effect=[_httpx_response(502) for _ in range(3)]
+    )
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    response = await utils.async_request_with_token(
+        "https://api.example.com/test", {"q": "x"}
+    )
+
+    assert response.status_code == 502
+    assert mock_client.get.call_count == 3
+
+
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_async_request_with_token_does_not_retry_on_404(mocker, settings):
+    """Deterministic 4xx responses are returned to the caller without retrying."""
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
+
+    mock_client = mocker.Mock()
+    mock_client.get = mocker.AsyncMock(return_value=_httpx_response(404))
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    response = await utils.async_request_with_token(
+        "https://api.example.com/test", {"q": "x"}
+    )
+
+    assert response.status_code == 404
+    assert mock_client.get.call_count == 1
+
+
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_async_request_with_token_retries_on_connect_error(mocker, settings):
+    """Transient transport exceptions are retried."""
+    settings.LEARN_ACCESS_TOKEN = "test_token"  # noqa: S105
+
+    mock_client = mocker.Mock()
+    mock_client.get = mocker.AsyncMock(
+        side_effect=[
+            httpx.ConnectError("boom"),
+            _httpx_response(200),
+        ]
+    )
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    response = await utils.async_request_with_token(
+        "https://api.example.com/test", {"q": "x"}
+    )
+
+    assert response.status_code == 200
+    assert mock_client.get.call_count == 2
+
+
 def test_get_sync_http_client_singleton():
     """Test that get_sync_http_client returns the same instance."""
     client1 = utils.get_sync_http_client()

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -112,7 +112,6 @@ class TestSettings(TestCase):
             ):
                 self.reload_settings()
 
-
     def test_server_side_cursors_enabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be false if MITOL_DB_DISABLE_SS_CURSORS is false"""
         with mock.patch.dict(


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/8531

### Description (What does it do?)
Adds retries for tool calls to search endpoints since they occasionally return 502's or other errors.

### How can this be tested?
- Save this [mock api endpoint server](https://gist.githubusercontent.com/mbertrand/41526245464ea70f8f0adea56bc61436/raw/a79baeb49637c7b9248e1ab275eabb0e6eca49e0/mock-search-endpoint.py) locally
- Start it up with `python mock_search_endpoint.py --port 8765`
- In another terminal, try this curl command, you should get a response back with 1 suggested course.  If you look at the mock endpoint log, you should see 3 calls, the first 2 returning 502's and the last returning a 200:
  ```bash
   curl -N -X POST http://localhost:8005/http/recommendation_agent/ \
   -H "Content-Type: application/json" \
   --data '{"message":"Find me machine learning courses", "search_url":"http://host.docker.internal:8765/flaky-502-then-200"}
   ```
