### PR TITLE
fix: install OpenLIT tracer provider in the else branch

### DIFF
--- a/main/openlit_keycloak_auth.py
+++ b/main/openlit_keycloak_auth.py
@@ -284,6 +284,7 @@ def _install_authed_providers(auth: KeycloakClientCredentialsAuth) -> None:
         # OpenLIT as an additional (openlit-scope-only) export destination.
         resource = existing_tracer_provider.resource
         existing_tracer_provider.add_span_processor(span_processor)
+    else:
         tracer_provider = TracerProvider(resource=resource)
         tracer_provider.add_span_processor(span_processor)
         trace.set_tracer_provider(tracer_provider)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`main` has been failing two OpenLIT tests since PR #560 (`d28c1b0`) merged. That PR landed the tracer-provider install logic and its tests in the same commit, but the create/`set_tracer_provider` block was nested **inside** the `isinstance(existing_tracer_provider, TracerProvider)` branch instead of in an `else`. As a result:

- When an SDK `TracerProvider` already exists (set by mitol-django-observability), the code overwrote it via `set_tracer_provider` instead of extending it — `test_install_reuses_existing_tracer_provider` fails with "Called 1 times".
- When no SDK provider exists (proxy default), the entire block is skipped and no provider is set — `test_install_creates_tracer_provider_when_absent` fails with "Called 0 times".

This PR moves the create-and-set block into an `else`, so an existing provider is extended in place and a new provider is created/set only when one is absent. This is the same one-line fix authored on the `md/202607_opik_enhancements` branch (commit `4f0574a`) that was never merged back to `main`.

### How can this be tested?

Run the OpenLIT auth test module:

```
docker compose run --rm web pytest main/openlit_keycloak_auth_test.py
```

Result: 14 passed. The two previously failing tests (`test_install_reuses_existing_tracer_provider` and `test_install_creates_tracer_provider_when_absent`) now pass.

### Additional Context

`main` is currently red on these tests, so any branch cut from `main` inherits the failure. The `md/202607_opik_enhancements` branch already carries this same fix (`4f0574a`); once this merges, that branch should be rebased on `main` so the duplicate commit drops out.