### PR TITLE
AskTim zendesk search tool

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -46,7 +46,7 @@ from ai_chatbots.api import (
 from ai_chatbots.posthog import TokenTrackingCallbackHandler
 from ai_chatbots.prompts import CONTEXT_LOST_PROMPT, SYSTEM_PROMPT_MAPPING
 from ai_chatbots.utils import (
-    async_request_with_token,
+    async_request,
     get_django_cache,
     save_truncated_checkpoint,
     truncate_to_latest_human_message,
@@ -534,6 +534,7 @@ class SyllabusBot(TruncatingChatbot):
         bot_tools = [tools.search_content_files]
         if self.enable_related_courses:
             bot_tools.append(tools.search_related_course_content_files)
+        bot_tools.append(tools.search_support_articles)
         return bot_tools
 
     async def get_tool_metadata(self) -> str:
@@ -746,7 +747,9 @@ async def get_problem_from_edx_block(
     api_url = settings.AI_MIT_CONTENTFILE_URL
     params = {"edx_module_id": block_siblings}
 
-    response = await async_request_with_token(api_url, params, timeout=10)
+    response = await async_request(
+        api_url, params, timeout=10, include_learn_token=True
+    )
 
     response = response.json()
 
@@ -776,7 +779,7 @@ async def get_canvas_problem_set(
 
     api_url = f"{settings.PROBLEM_SET_URL}{run_readable_id}/{problem_set_title}/"
 
-    response = await async_request_with_token(api_url, {}, timeout=10)
+    response = await async_request(api_url, {}, timeout=10, include_learn_token=True)
     response = response.json()
 
     return {

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -386,6 +386,23 @@ async def test_syllabus_bot_no_related_courses_instructions(mocker, mock_checkpo
     assert "search_related_course_content_files" not in chatbot.instructions
 
 
+@pytest.mark.parametrize("enable_related_courses", [True, False])
+@pytest.mark.asyncio
+async def test_syllabus_bot_tools(mocker, mock_checkpointer, enable_related_courses):
+    """SyllabusBot should have the support article search tool."""
+    mocker.patch("ai_chatbots.chatbots.create_react_agent")
+    chatbot = await sync_to_async(SyllabusBot)(
+        "anonymous",
+        mock_checkpointer,
+        thread_id="12345678-1234-5678-9abc-123456789abc",
+        enable_related_courses=enable_related_courses,
+    )
+    expected_tools = ["search_content_files", "search_support_articles"]
+    if enable_related_courses:
+        expected_tools.insert(1, "search_related_course_content_files")
+    assert [tool.name for tool in chatbot.create_tools()] == expected_tools
+
+
 @pytest.mark.parametrize("default_model", ["gpt-3.5-turbo", "gpt-4", "gpt-4o"])
 @pytest.mark.asyncio
 async def test_syllabus_bot_get_completion_state(

--- a/ai_chatbots/conftest.py
+++ b/ai_chatbots/conftest.py
@@ -143,6 +143,13 @@ def content_chunk_results():
 
 
 @pytest.fixture
+def zendesk_article_results():
+    """Return Zendesk help center article search results for testing."""
+    with Path.open("./test_json/zendesk_articles.json") as f:
+        yield json.loads(f.read())
+
+
+@pytest.fixture
 def video_transcript_content_chunk_results():
     """Return content file vector chunks for testing video GPT."""
     with Path.open("./test_json/video_transcript_chunks.json") as f:

--- a/ai_chatbots/constants.py
+++ b/ai_chatbots/constants.py
@@ -43,6 +43,22 @@ class OfferedBy(ExtendedEnum):
     see = "MIT Sloan Executive Education"
 
 
+class SupportPortal(ExtendedEnum):
+    """
+    Enum for the MIT support portals (Zendesk help centers) that
+    the chatbots can search. Names must match the keys of the
+    settings.AI_ZENDESK_PORTAL_URLS dict.
+    """
+
+    mitxonline = "MITx Online"
+    ocw = "MIT OpenCourseWare"
+    mitlearn = "MIT Learn"
+
+
+# Zendesk help center article search endpoint, appended to a portal base url
+ZENDESK_ARTICLE_SEARCH_PATH = "/api/v2/help_center/articles/search.json"
+
+
 class ChatResponseScore(ExtendedEnum):
     """Enum for chat response ratings"""
 

--- a/ai_chatbots/consumers_test.py
+++ b/ai_chatbots/consumers_test.py
@@ -383,7 +383,9 @@ async def test_syllabus_create_chatbot_with_related_courses(
     )
     assert isinstance(chatbot, SyllabusBot)
     assert chatbot.enable_related_courses is True
-    assert len(chatbot.create_tools()) == 2
+    assert "search_related_course_content_files" in [
+        tool.name for tool in chatbot.create_tools()
+    ]
 
 
 async def test_syllabus_create_chatbot_without_related_courses(
@@ -403,7 +405,9 @@ async def test_syllabus_create_chatbot_without_related_courses(
     )
     assert isinstance(chatbot, SyllabusBot)
     assert chatbot.enable_related_courses is False
-    assert len(chatbot.create_tools()) == 1
+    assert "search_related_course_content_files" not in [
+        tool.name for tool in chatbot.create_tools()
+    ]
 
 
 @pytest.mark.parametrize(

--- a/ai_chatbots/prompts.py
+++ b/ai_chatbots/prompts.py
@@ -101,6 +101,14 @@ question.  The search function already has the resource identifier.
 2. Provide a clear, user-friendly summary of the information retrieved by the tool to
 answer the user's question.
 
+If the user asks how the platform hosting the resource works rather than about the
+resource content itself - enrollment, certificates, payments and refunds, deadlines,
+accounts and logins, or technical problems - use the "search_support_articles" tool to
+search the MIT support portals, and answer based on those articles.  Always set that
+tool's "platform" parameter when the platform is clear from the resource under
+discussion, so that the correct support portal is searched.  Link to the support
+article urls returned by the tool so the user can read the full answer.
+
 Always use the tool results to answer questions, and answer only based on the tool
 output. Do not include the course_id in the query parameter.  The tool always has
 access to the course id.
@@ -122,6 +130,14 @@ question.  The search function already has the resource identifier.
 answer the user's question.
 
 {citations}
+
+If the user asks how the platform hosting the resource works rather than about the
+resource content itself - enrollment, certificates, payments and refunds, deadlines,
+accounts and logins, or technical problems - use the "search_support_articles" tool to
+search the MIT support portals, and answer based on those articles.  Always set that
+tool's "platform" parameter when the platform is clear from the resource under
+discussion, so that the correct support portal is searched.  Link to the support
+article urls returned by the tool so the user can read the full answer.
 
 Always use the tool results to answer questions, and answer only based on the tool
 output. Do not include the course_id in the query parameter.  The tool always has

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -22,7 +22,7 @@ from ai_chatbots.constants import (
     OfferedBy,
     SupportPortal,
 )
-from ai_chatbots.utils import async_request, async_request_with_token, enum_zip
+from ai_chatbots.utils import async_request, enum_zip
 from main.features import is_enabled as feature_is_enabled
 
 log = logging.getLogger(__name__)
@@ -161,8 +161,11 @@ async def search_courses(
     search_url = state["search_url"][-1] if state else settings.AI_MIT_SEARCH_URL
     log.debug("Searching MIT resources API at %s with params: %s", search_url, params)
     try:
-        response = await async_request_with_token(
-            search_url, params, timeout=settings.REQUESTS_TIMEOUT
+        response = await async_request(
+            search_url,
+            params,
+            timeout=settings.REQUESTS_TIMEOUT,
+            include_learn_token=True,
         )
         response.raise_for_status()
         raw_results = response.json().get("results", [])
@@ -271,8 +274,8 @@ async def _content_file_search(url, params, *, exclude_canvas=True):
         if await _is_hybrid_search_enabled():
             params["hybrid_search"] = True
 
-        response = await async_request_with_token(
-            url, params, timeout=settings.REQUESTS_TIMEOUT
+        response = await async_request(
+            url, params, timeout=settings.REQUESTS_TIMEOUT, include_learn_token=True
         )
         response.raise_for_status()
         raw_results = response.json().get("results", [])
@@ -373,8 +376,8 @@ async def get_video_transcript_chunk(
 
     log.debug("Searching MIT API with params: %s", params)
     try:
-        response = await async_request_with_token(
-            url, params, timeout=settings.REQUESTS_TIMEOUT
+        response = await async_request(
+            url, params, timeout=settings.REQUESTS_TIMEOUT, include_learn_token=True
         )
         response.raise_for_status()
         raw_results = response.json().get("results", [])

--- a/ai_chatbots/tools.py
+++ b/ai_chatbots/tools.py
@@ -1,11 +1,14 @@
 """Tools and schemas for AI agents"""
 
+import asyncio
+import itertools
 import json
 import logging
 from typing import Annotated
 
 import pydantic
 from asgiref.sync import sync_to_async
+from bs4 import BeautifulSoup
 from django.conf import settings
 from httpx import HTTPStatusError, RequestError
 from langchain_core.tools import tool
@@ -14,10 +17,12 @@ from pydantic import Field
 
 from ai_chatbots.constants import (
     HYBRID_SEARCH_FEATURE_FLAG,
+    ZENDESK_ARTICLE_SEARCH_PATH,
     LearningResourceType,
     OfferedBy,
+    SupportPortal,
 )
-from ai_chatbots.utils import async_request_with_token, enum_zip
+from ai_chatbots.utils import async_request, async_request_with_token, enum_zip
 from main.features import is_enabled as feature_is_enabled
 
 log = logging.getLogger(__name__)
@@ -389,3 +394,148 @@ async def get_video_transcript_chunk(
     except Exception:
         log.exception("Error querying MIT API for transcripts")
         return json.dumps({"error": "An error occurred while getting the transcript"})
+
+
+class SearchSupportArticlesToolSchema(pydantic.BaseModel):
+    """
+    Schema to search MIT support portals (help centers) for articles about
+    how MIT platforms work: enrollment, certificates, refunds, payments,
+    account and login issues, deadlines, technical problems, etc.
+
+    Here are some recommended tool parameters to apply for sample user prompts:
+
+    User: "How do I get a certificate for my MITx Online course?"
+    Search parameters: q="certificate", platform=["mitxonline"]
+
+    User: "Can I get credit for OpenCourseWare courses?"
+    Search parameters: q="credit", platform=["ocw"]
+
+    User: "I can't log in to MIT Learn"
+    Search parameters: q="login", platform=["mitlearn"]
+
+    User: "How do refunds work?"
+    Search parameters: q="refund"
+    """
+
+    q: str = Field(
+        description=(
+            """
+            Keywords describing the support question, i.e. "certificate", "refund",
+            "unenroll", "password reset".  Use a few keywords rather than a full
+            sentence, since this is a keyword search rather than a semantic one.
+            """
+        )
+    )
+
+    platform: list[enum_zip("platform", SupportPortal)] | None = Field(
+        default=None,
+        description="""
+            The support portal(s) to search, based on the MIT platform the user is
+            asking about:
+
+                mitxonline = MITx Online (also use for MITx courses/programs)
+                ocw = MIT OpenCourseWare
+                mitlearn = MIT Learn (learn.mit.edu), and other MIT Open Learning
+                    offerings such as xPRO, Professional Education,
+                    Sloan Executive Education and Bootcamps
+
+            Always set this parameter if the platform is clear from the user's
+            question or from the resources under discussion.  If the platform is
+            ambiguous, omit it and all portals will be searched.
+            """,
+    )
+
+
+def _simplify_zendesk_article(article: dict, platform: str) -> dict:
+    """
+    Convert a Zendesk help center article into a simplified dict,
+    with the html body converted to truncated plain text.
+    """
+    body_text = BeautifulSoup(article.get("body") or "", "html.parser").get_text(
+        " ", strip=True
+    )
+    return {
+        "id": f"{platform}-{article.get('id')}",
+        "title": article.get("title"),
+        "url": article.get("html_url"),
+        "platform": platform,
+        "updated_at": article.get("updated_at"),
+        "content": body_text[: settings.AI_ZENDESK_ARTICLE_MAX_CHARS],
+    }
+
+
+async def _search_zendesk_portal(platform: str, portal_url: str, params: dict) -> list:
+    """
+    Search one Zendesk help center and return simplified articles,
+    in Zendesk relevance order.  Returns an empty list on error, so that
+    one unavailable portal does not fail the entire search.
+    """
+    search_url = f"{portal_url.rstrip('/')}{ZENDESK_ARTICLE_SEARCH_PATH}"
+    try:
+        # These are public help centers, so no authentication is sent
+        response = await async_request(
+            search_url, params, timeout=settings.REQUESTS_TIMEOUT
+        )
+        response.raise_for_status()
+        return [
+            _simplify_zendesk_article(article, platform)
+            for article in response.json().get("results", [])
+        ]
+    except Exception:
+        log.exception(
+            "Error querying the %s support portal at %s", platform, search_url
+        )
+        return []
+
+
+@tool(args_schema=SearchSupportArticlesToolSchema)
+async def search_support_articles(q: str, **kwargs) -> str:
+    """
+    Search the MIT support portals (help centers) for up to date articles
+    answering questions about how MIT platforms work, such as enrollment,
+    certificates, refunds, payments, accounts, logins, deadlines and
+    technical issues.  Returns the articles as a JSON string.
+    """
+    platforms = [p.name for p in (kwargs.get("platform") or [])]
+    portals = {
+        platform: url
+        for platform, url in settings.AI_ZENDESK_PORTAL_URLS.items()
+        if url and (not platforms or platform in platforms)
+    }
+    if not portals:
+        log.warning("No support portals configured for platforms: %s", platforms)
+        return json.dumps({"results": []})
+
+    limit = settings.AI_ZENDESK_SEARCH_LIMIT
+    params = {"query": q, "per_page": limit}
+    portal_results = await asyncio.gather(
+        *[
+            _search_zendesk_portal(platform, url, params)
+            for platform, url in portals.items()
+        ]
+    )
+    # Interleave the portal results so that the most relevant articles from
+    # each portal are kept when the overall limit is applied.
+    articles = [
+        article
+        for article in itertools.chain.from_iterable(
+            itertools.zip_longest(*portal_results)
+        )
+        if article
+    ][:limit]
+    full_output = {
+        "results": articles,
+        "citation_sources": {
+            article["id"]: {
+                "citation_url": article["url"],
+                "citation_title": article["title"],
+            }
+            for article in articles
+            if article["url"]
+        },
+        "metadata": {
+            "search_urls": list(portals.values()),
+            "parameters": {**params, "platform": list(portals.keys())},
+        },
+    }
+    return json.dumps(full_output)

--- a/ai_chatbots/tools_test.py
+++ b/ai_chatbots/tools_test.py
@@ -10,7 +10,14 @@ from ai_chatbots.tools import (
     search_content_files,
     search_courses,
     search_related_course_content_files,
+    search_support_articles,
 )
+
+ZENDESK_PORTAL_URLS = {
+    "mitxonline": "https://mitxonline.zendesk.com",
+    "ocw": "https://mitocw.zendesk.com",
+    "mitlearn": "https://support.learn.mit.edu",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -413,3 +420,158 @@ async def test_search_courses_hybrid_flag(
         headers={"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"},
         timeout=30,
     )
+
+
+@pytest.fixture
+def mock_get_zendesk_articles(mock_httpx_async_client, zendesk_article_results):
+    """Mock httpx async requests for Zendesk support article tests."""
+    return mock_httpx_async_client(
+        zendesk_article_results, patch_path="ai_chatbots.utils.get_async_http_client"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _zendesk_settings(settings):
+    """Assign default Zendesk portal settings."""
+    settings.AI_ZENDESK_PORTAL_URLS = dict(ZENDESK_PORTAL_URLS)
+    settings.AI_ZENDESK_SEARCH_LIMIT = 5
+    settings.AI_ZENDESK_ARTICLE_MAX_CHARS = 1500
+
+
+@pytest.mark.parametrize("platform", ["mitxonline", "ocw", "mitlearn"])
+async def test_search_support_articles(
+    settings, mock_get_zendesk_articles, zendesk_article_results, platform
+):
+    """The tool should query only the portal matching the requested platform."""
+    settings.AI_ZENDESK_SEARCH_LIMIT = 3
+    results = json.loads(
+        await search_support_articles.ainvoke(
+            {"q": "certificate", "platform": [platform]}
+        )
+    )
+
+    # No authorization is sent to the public help centers
+    mock_get_zendesk_articles.return_value.get.assert_called_once_with(
+        f"{ZENDESK_PORTAL_URLS[platform]}/api/v2/help_center/articles/search.json",
+        params={"query": "certificate", "per_page": 3},
+        headers={},
+        timeout=30,
+    )
+    expected_articles = zendesk_article_results["results"]
+    assert len(results["results"]) == len(expected_articles)
+    first_result = results["results"][0]
+    first_article = expected_articles[0]
+    assert first_result["id"] == f"{platform}-{first_article['id']}"
+    assert first_result["title"] == first_article["title"]
+    assert first_result["url"] == first_article["html_url"]
+    assert first_result["platform"] == platform
+    # The html body should be converted to plain text
+    assert "<" not in first_result["content"]
+    assert first_result["content"].startswith(
+        "What Are The Two Course Enrollment Tracks?"
+    )
+    assert results["citation_sources"][first_result["id"]] == {
+        "citation_url": first_article["html_url"],
+        "citation_title": first_article["title"],
+    }
+    assert results["metadata"]["parameters"]["platform"] == [platform]
+
+
+async def test_search_support_articles_all_portals(mock_get_zendesk_articles):
+    """All portals should be searched, and interleaved results capped at the limit."""
+    results = json.loads(await search_support_articles.ainvoke({"q": "refund"}))
+
+    mock_client = mock_get_zendesk_articles.return_value
+    assert mock_client.get.call_count == len(ZENDESK_PORTAL_URLS)
+    assert [call.args[0] for call in mock_client.get.call_args_list] == [
+        f"{url}/api/v2/help_center/articles/search.json"
+        for url in ZENDESK_PORTAL_URLS.values()
+    ]
+    # 3 articles per portal, interleaved by relevance rank and capped at 5
+    assert [result["platform"] for result in results["results"]] == [
+        "mitxonline",
+        "ocw",
+        "mitlearn",
+        "mitxonline",
+        "ocw",
+    ]
+    assert results["metadata"]["parameters"]["platform"] == list(ZENDESK_PORTAL_URLS)
+
+
+async def test_search_support_articles_truncates_content(
+    settings, mock_get_zendesk_articles
+):
+    """Article text should be truncated to the configured max length."""
+    settings.AI_ZENDESK_ARTICLE_MAX_CHARS = 20
+    results = json.loads(
+        await search_support_articles.ainvoke(
+            {"q": "certificate", "platform": ["mitxonline"]}
+        )
+    )
+    assert [len(result["content"]) for result in results["results"]] == [20, 20, 20]
+
+
+async def test_search_support_articles_skips_unconfigured_portals(
+    settings, mock_get_zendesk_articles
+):
+    """Portals without a configured url should not be searched."""
+    settings.AI_ZENDESK_PORTAL_URLS = {**ZENDESK_PORTAL_URLS, "ocw": ""}
+    results = json.loads(await search_support_articles.ainvoke({"q": "refund"}))
+
+    assert {result["platform"] for result in results["results"]} == {
+        "mitxonline",
+        "mitlearn",
+    }
+    assert mock_get_zendesk_articles.return_value.get.call_count == 2
+
+
+async def test_search_support_articles_no_portals(settings, mock_get_zendesk_articles):
+    """An empty result is returned if no portal is configured for the platform."""
+    settings.AI_ZENDESK_PORTAL_URLS = {**ZENDESK_PORTAL_URLS, "ocw": ""}
+    result = json.loads(
+        await search_support_articles.ainvoke({"q": "credit", "platform": ["ocw"]})
+    )
+    assert result == {"results": []}
+    mock_get_zendesk_articles.return_value.get.assert_not_called()
+
+
+@pytest.mark.usefixtures("_no_retry_sleep")
+async def test_search_support_articles_portal_error(
+    mocker, mock_httpx_async_client, zendesk_article_results
+):
+    """A failing portal should not prevent results from the other portals."""
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = zendesk_article_results
+    mock_response.status_code = 200
+    mock_response.raise_for_status = mocker.Mock()
+
+    connection_error = RequestError("Connection error")
+
+    def _get(url, **kwargs):
+        """Fail every request to the MITx Online portal."""
+        if url.startswith(ZENDESK_PORTAL_URLS["mitxonline"]):
+            raise connection_error
+        return mock_response
+
+    mock_client = mock_httpx_async_client(zendesk_article_results)
+    mock_client.get = mocker.AsyncMock(side_effect=_get)
+    mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
+
+    results = json.loads(await search_support_articles.ainvoke({"q": "refund"}))
+
+    # The failing portal exhausts its retries and is dropped from the results
+    assert {result["platform"] for result in results["results"]} == {"ocw", "mitlearn"}
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"platform": ["mitxonline"]},
+        {"q": "certificate", "platform": ["mitx"]},
+        {"q": "certificate", "platform": "mitxonline"},
+    ],
+)
+def test_invalid_support_article_params(params):
+    """Test that invalid support search parameters raise a validation error."""
+    with pytest.raises(ValidationError):
+        search_support_articles.invoke(params)

--- a/ai_chatbots/utils.py
+++ b/ai_chatbots/utils.py
@@ -176,9 +176,11 @@ def request_with_token(url, params, follow_redirects, timeout: int = 30):
     )
 
 
-async def async_request_with_token(url, params, timeout: int = 30):
+async def async_request(
+    url, params, timeout: int = 30, *, include_learn_token: bool = False
+):
     """
-        Make an async bearer-authenticated GET request.
+        Make an async GET request.
 
         Retries transient transport errors and retryable upstream statuses up to
         ``_RETRY_MAX_ATTEMPTS`` times. Returns the final response, or reraises the
@@ -188,12 +190,18 @@ async def async_request_with_token(url, params, timeout: int = 30):
         url: The URL to request
         params: Query parameters
         timeout: Request timeout in seconds
+        include_learn_token: Authenticate with the MIT Learn bearer token.
+            Only enable this for MIT Learn APIs, never for third party ones.
 
     Returns:
         httpx.Response object with compatible interface to requests.Response
     """
     client = get_async_http_client()
-    headers = {"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"}
+    headers = (
+        {"Authorization": f"Bearer {settings.LEARN_ACCESS_TOKEN}"}
+        if include_learn_token
+        else {}
+    )
 
     for attempt in range(_RETRY_MAX_ATTEMPTS):
         try:

--- a/ai_chatbots/utils_test.py
+++ b/ai_chatbots/utils_test.py
@@ -64,8 +64,8 @@ def test_request_with_token(mocker, settings):
     assert response.json() == {"result": "success"}
 
 
-async def test_async_request_with_token(mocker, settings):
-    """Test asynchronous async_request_with_token function."""
+async def test_async_request_with_learn_token(mocker, settings):
+    """async_request should send the Learn token when asked to."""
     settings.LEARN_ACCESS_TOKEN = "test_token_456"  # noqa: S105
 
     mock_response = mocker.Mock()
@@ -78,8 +78,11 @@ async def test_async_request_with_token(mocker, settings):
 
     mocker.patch("ai_chatbots.utils.get_async_http_client", return_value=mock_client)
 
-    response = await utils.async_request_with_token(
-        "https://api.example.com/async", {"param2": "value2"}, timeout=20
+    response = await utils.async_request(
+        "https://api.example.com/async",
+        {"param2": "value2"},
+        timeout=20,
+        include_learn_token=True,
     )
 
     mock_client.get.assert_called_once_with(
@@ -90,6 +93,24 @@ async def test_async_request_with_token(mocker, settings):
     )
     assert response.status_code == 200
     assert response.json() == {"result": "async_success"}
+
+
+async def test_async_request_omits_learn_token_by_default(
+    mock_async_get_client, httpx_response, settings
+):
+    """async_request should not leak the Learn token to third party APIs."""
+    settings.LEARN_ACCESS_TOKEN = "test_token_789"  # noqa: S105
+
+    mock_client = mock_async_get_client(return_value=httpx_response(200))
+
+    await utils.async_request("https://third.party.example.com/api", {"q": "x"})
+
+    mock_client.get.assert_called_once_with(
+        "https://third.party.example.com/api",
+        params={"q": "x"},
+        headers={},
+        timeout=30,
+    )
 
 
 @pytest.mark.usefixtures("_no_retry_sleep")
@@ -106,7 +127,7 @@ async def test_async_request_with_token(mocker, settings):
         "does-not-retry-on-404",
     ],
 )
-async def test_async_request_with_token_status_handling(
+async def test_async_request_status_handling(
     mock_async_get_client,
     httpx_response,
     statuses,
@@ -118,16 +139,14 @@ async def test_async_request_with_token_status_handling(
         side_effect=[httpx_response(status) for status in statuses]
     )
 
-    response = await utils.async_request_with_token(
-        "https://api.example.com/test", {"q": "x"}
-    )
+    response = await utils.async_request("https://api.example.com/test", {"q": "x"})
 
     assert response.status_code == expected_status
     assert mock_client.get.call_count == expected_calls
 
 
 @pytest.mark.usefixtures("_no_retry_sleep")
-async def test_async_request_with_token_retries_on_connect_error(
+async def test_async_request_retries_on_connect_error(
     mock_async_get_client, httpx_response
 ):
     """Retry transient transport errors."""
@@ -138,9 +157,7 @@ async def test_async_request_with_token_retries_on_connect_error(
         ]
     )
 
-    response = await utils.async_request_with_token(
-        "https://api.example.com/test", {"q": "x"}
-    )
+    response = await utils.async_request("https://api.example.com/test", {"q": "x"})
 
     assert response.status_code == 200
     assert mock_client.get.call_count == 2

--- a/main/settings.py
+++ b/main/settings.py
@@ -716,6 +716,23 @@ AI_BUDGET_DURATION = get_string(name="AI_BUDGET_DURATION", default="60m")
 AI_MAX_BUDGET = get_float(name="AI_MAX_BUDGET", default=0.05)
 AI_ANON_LIMIT_MULTIPLIER = get_float(name="AI_ANON_LIMIT_MULTIPLIER", default=10.0)
 
+AI_ZENDESK_PORTAL_URLS = {
+    "mitxonline": get_string(
+        name="AI_ZENDESK_MITXONLINE_URL", default="https://mitxonline.zendesk.com"
+    ),
+    "ocw": get_string(name="AI_ZENDESK_OCW_URL", default="https://mitocw.zendesk.com"),
+    "mitlearn": get_string(
+        name="AI_ZENDESK_MITLEARN_URL", default="https://support.learn.mit.edu"
+    ),
+}
+# Max number of support articles returned by the support search tool per request
+AI_ZENDESK_SEARCH_LIMIT = get_int(name="AI_ZENDESK_SEARCH_LIMIT", default=5)
+# Max number of characters of article text passed back to the LLM per article
+AI_ZENDESK_ARTICLE_MAX_CHARS = get_int(
+    name="AI_ZENDESK_ARTICLE_MAX_CHARS", default=1500
+)
+
+
 # APISIX middleware settings
 APISIX_USERDATA_MAP = {
     "users_user": {

--- a/test_json/zendesk_articles.json
+++ b/test_json/zendesk_articles.json
@@ -1,0 +1,46 @@
+{
+  "count": 70,
+  "page": 1,
+  "per_page": 3,
+  "results": [
+    {
+      "id": 28158506908699,
+      "html_url": "https://mitxonline.zendesk.com/hc/en-us/articles/28158506908699-What-is-the-Certificate-Track-What-are-Course-and-Program-Certificates",
+      "title": "What is the Certificate Track? What are Course and Program Certificates?",
+      "name": "What is the Certificate Track? What are Course and Program Certificates?",
+      "locale": "en-us",
+      "created_at": "2024-08-09T23:14:48Z",
+      "updated_at": "2026-07-24T18:59:44Z",
+      "section_id": 13765526851867,
+      "body": "<h1 id=\"h_01J547BJG65B95WST3F4GX3VN9\">What Are The Two Course Enrollment Tracks?</h1>\n<p>The MITx Online Platform features two Enrollment Tracks, which offer learners slightly different experiences. All MITx Online courses, with very few exceptions\u2020, offer an Audit (free) Enrollment Track. Many, but not all, MITx Online courses also offer a Verified/Certificate (Paid) Enrollment Track.</p>\n<ul>\n<l",
+      "snippet": "on the <em>Certificate</em> Track are eligible to earn a Course <em>Certificate</em>. MITx Online does not offer any free <em>Certificates</em> For",
+      "result_type": "article"
+    },
+    {
+      "id": 13866503633819,
+      "html_url": "https://mitxonline.zendesk.com/hc/en-us/articles/13866503633819-What-happens-if-I-pay-for-a-certificate-and-then-fail-the-course-Will-a-certificate-be-issued-to-me",
+      "title": "What happens if I pay for a certificate and then fail the course? Will a certificate be issued to me?",
+      "name": "What happens if I pay for a certificate and then fail the course? Will a certificate be issued to me?",
+      "locale": "en-us",
+      "created_at": "2023-03-21T20:31:32Z",
+      "updated_at": "2024-05-02T02:59:32Z",
+      "section_id": 13765526851867,
+      "body": "<p>When you upgrade to the certificate track, it indicates your commitment to completing the course requirements and gives you the opportunity to earn a certificate upon successful completion. However, it's important to note that upgrading to the certificate track does not guarantee a passing grade in the course or the issuance of a certificate.</p>\n<p>\u00a0</p>\n<p>MITx Online courses require learners",
+      "snippet": "earn a <em>certificate</em> upon successful completion. However, it's important to note that upgrading to the <em>certificate</em> track does",
+      "result_type": "article"
+    },
+    {
+      "id": 16928447060635,
+      "html_url": "https://mitxonline.zendesk.com/hc/en-us/articles/16928447060635-Can-I-get-a-paper-copy-of-my-certificate",
+      "title": "Can I get a paper copy of my certificate?",
+      "name": "Can I get a paper copy of my certificate?",
+      "locale": "en-us",
+      "created_at": "2023-07-06T18:26:55Z",
+      "updated_at": "2026-07-22T22:59:49Z",
+      "section_id": 13765526851867,
+      "body": "<p>MITx Online Course and Program Certificates are delivered exclusively in electronic format as soft copies. MITx Online does not provide physical certificates in hard copy form.</p>\n<p>However, learners can download and then print their Course and Program Certificates, via the Print-to-PDF function of most modern web browsers and operating systems, to generate their own hard copy.</p>\n<ul>\n<li><",
+      "snippet": "MITx Online Course and Program <em>Certificates</em> are delivered exclusively in electronic format as soft copies. MITx Online does",
+      "result_type": "article"
+    }
+  ]
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12318
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR adds zendesk support search as a tool that AskTim can use for [ocw](https://mitocw.zendesk.com), [mitxonline](https://mitxonline.zendesk.com/), and [learn](https://support.learn.mit.edu)

### How can this be tested?
1. checkout this branch
2. make sure LEARN_ACCESS_TOKEN is set in settings.py
3. run the following test cases which excercise different cases:


**support question**:
result: _uses zendesk tool:_
```bash
curl -N 'http://ai.open.odl.local:8002/http/syllabus_agent/' \
-H 'content-type: application/json' -H 'Origin: http://ai.open.odl.local:8002' \
--data-raw '{"message":"Can I get a refund if I unenroll from this course?","course_id":"MITx+6.00.1x"}'
```

**content question**:
result:  _does not use zendesk tool_:
```bash
curl -N 'http://ai.open.odl.local:8002/http/syllabus_agent/' -H 'content-type: application/json' \
-H 'Origin: http://ai.open.odl.local:8002' \
--data-raw '{"message":"What are the main topics covered in this course?","course_id":"MITx+6.00.1x"}'
```

**Support question _except with a different_ (ocw) paltform**:
result:  _uses tool except with ocw zendesk site_:
```bash
docker compose run --rm web python -c "import asyncio,django,json;django.setup();from ai_chatbots.tools import search_support_articles;print(json.dumps(asyncio.run(search_support_articles.ainvoke({'q':'certificate','platform':['mitxonline']})),indent=2))"
```
Confirm the metadata platform comes back as ["ocw"] with mitocw.zendesk.com links, rather than the MITx Online portal.


Try different queries and ensure it calls the right tool for the job

