### PR TITLE
Log LangGraph agent graph to Opik traces

### DIFF
--- a/ai_chatbots/chatbots.py
+++ b/ai_chatbots/chatbots.py
@@ -273,6 +273,10 @@ class BaseChatbot(ABC):
 
             callbacks.append(
                 CostTrackingOpikTracer(
+                    # Log the agent graph so Opik can render it in the trace
+                    # sidebar ("Show Agent Graph"). xray=True expands nested
+                    # subgraphs (e.g. ToolNode internals) for full visibility.
+                    graph=self.agent.get_graph(xray=True) if self.agent else None,
                     project_name=settings.OPIK_PROJECT_NAME,
                     thread_id=self.thread_id,
                     tags=[self.JOB_ID],

--- a/ai_chatbots/chatbots_test.py
+++ b/ai_chatbots/chatbots_test.py
@@ -343,6 +343,27 @@ async def test_recommendation_bot_create_agent_graph(mocker, mock_checkpointer):
 
 
 @pytest.mark.asyncio
+async def test_set_callbacks_logs_agent_graph_to_opik(mocker, mock_checkpointer):
+    """set_callbacks should pass the agent graph to the Opik tracer for logging."""
+    # Disable PostHog so the Opik tracer is the only callback added
+    mocker.patch.object(settings, "POSTHOG_API_HOST", None)
+    mocker.patch("ai_chatbots.chatbots.is_opik_configured", return_value=True)
+    mock_tracer = mocker.patch("ai_chatbots.opik_tracing.CostTrackingOpikTracer")
+    chatbot = await sync_to_async(ResourceRecommendationBot)(
+        "anonymous", mock_checkpointer, thread_id="12345678-1234-5678-9abc-123456789abc"
+    )
+    graph = mocker.Mock()
+    mocker.patch.object(chatbot.agent, "get_graph", return_value=graph)
+
+    callbacks = await chatbot.set_callbacks()
+
+    chatbot.agent.get_graph.assert_called_once_with(xray=True)
+    mock_tracer.assert_called_once()
+    assert mock_tracer.call_args.kwargs["graph"] is graph
+    assert mock_tracer.return_value in callbacks
+
+
+@pytest.mark.asyncio
 async def test_syllabus_bot_create_agent_graph(mocker, mock_checkpointer):
     """Test that create_agent_graph function calls create_react_agent with expected arguments"""
     mock_create_agent = mocker.patch("ai_chatbots.chatbots.create_react_agent")


### PR DESCRIPTION
### Description (What does it do?)
Passes `graph=self.agent.get_graph(xray=True)` to the Opik tracer so the agent graph renders in the Opik trace sidebar ("Show Agent Graph"). Applies to all chatbots since they all expose a compiled graph.

### How can this be tested?
With Opik configured, run a chat and open a trace in Opik — click "Show Agent Graph" in the sidebar to see the rendered graph. `ai_chatbots/opik_tracing_test.py` passes (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)